### PR TITLE
Use R-universe for faster arrow installation

### DIFF
--- a/.github/workflows/daily-scrape.yml
+++ b/.github/workflows/daily-scrape.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Setup R dependencies
       uses: r-lib/actions/setup-r-dependencies@v2
       with:
+        extra-repositories: https://apache.r-universe.dev
         packages: |
           any::remotes
           any::piggyback


### PR DESCRIPTION
## Summary
- Add Apache R-universe as extra repository for faster arrow package installation in GitHub Actions workflow

## Details
R-universe provides pre-built binaries which install much faster than compiling from CRAN source. This should reduce the daily scrape workflow's dependency installation time significantly (arrow compilation alone was taking ~10+ minutes).

🤖 Generated with [Claude Code](https://claude.ai/code)