### PR TITLE
Rename Opta workflow to daily schedule

### DIFF
--- a/.github/workflows/daily-opta-scrape.yml
+++ b/.github/workflows/daily-opta-scrape.yml
@@ -1,9 +1,9 @@
-name: Weekly Opta Scrape
+name: Daily Opta Scrape
 
 on:
   schedule:
-    # Run weekly on Monday at 3 AM UTC
-    - cron: '0 3 * * 1'
+    # Run at 5 AM UTC daily (before Understat at 7 AM)
+    - cron: '0 5 * * *'
   workflow_dispatch:
     inputs:
       leagues:


### PR DESCRIPTION
## Summary
- Rename `weekly-opta-scrape.yml` → `daily-opta-scrape.yml`
- Change schedule from weekly (Monday 3 AM UTC) to daily (5 AM UTC)

## Schedule
| Workflow | Time (UTC) |
|----------|------------|
| FBref (VM cron) | 6 AM |
| Opta | 5 AM |
| Understat | 7 AM |

🤖 Generated with [Claude Code](https://claude.ai/code)