### PR TITLE
Smart per-league Understat scraper with manifest tracking

### DIFF
--- a/.github/workflows/daily-understat-scrape.yml
+++ b/.github/workflows/daily-understat-scrape.yml
@@ -6,16 +6,18 @@ on:
     - cron: '0 7 * * *'
   workflow_dispatch:
     inputs:
-      start_id:
-        description: 'Start match ID (leave empty for auto-detect)'
+      lookback:
+        description: 'IDs to look back from max (default: 20)'
         required: false
         type: string
-      end_id:
-        description: 'End match ID (leave empty for auto-detect +500)'
+        default: '20'
+      max_misses:
+        description: 'Stop after N consecutive misses per league (default: 50)'
         required: false
         type: string
+        default: '50'
       force_rescrape:
-        description: 'Force rescrape cached matches'
+        description: 'Rebuild manifest from scratch'
         required: false
         type: boolean
         default: false
@@ -97,7 +99,49 @@ jobs:
         '
       shell: bash
 
-    - name: Run incremental Understat scrape
+    - name: Download manifest from GitHub Releases
+      run: |
+        echo "Downloading Understat manifest..."
+        gh release download understat-latest \
+          --pattern "understat-manifest.parquet" \
+          --dir data/ \
+          --repo peteowen1/pannadata 2>/dev/null || echo "No existing manifest found (first run)"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Build manifest from cache if needed
+      run: |
+        Rscript -e '
+          library(panna)
+
+          pannadata_dir(file.path(getwd(), "data"))
+          manifest_path <- file.path(getwd(), "data", "understat-manifest.parquet")
+
+          force_rebuild <- as.logical("${{ github.event.inputs.force_rescrape }}")
+          if (is.na(force_rebuild)) force_rebuild <- FALSE
+
+          if (force_rebuild || !file.exists(manifest_path)) {
+            message("Building manifest from existing cache...")
+            manifest <- build_understat_manifest_from_cache(file.path(getwd(), "data"))
+
+            if (nrow(manifest) > 0) {
+              save_understat_manifest(manifest, manifest_path)
+              message(sprintf("Built manifest with %d matches", nrow(manifest)))
+
+              # Show league breakdown
+              message("\nLeague breakdown:")
+              print(table(manifest$league))
+            } else {
+              message("No existing data to build manifest from")
+            }
+          } else {
+            manifest <- load_understat_manifest(manifest_path)
+            message(sprintf("Loaded existing manifest with %d matches", nrow(manifest)))
+          }
+        '
+      shell: bash
+
+    - name: Run smart Understat scraper
       run: |
         Rscript -e '
           library(panna)
@@ -106,57 +150,29 @@ jobs:
           pannadata_dir(file.path(getwd(), "data"))
 
           # Configuration from inputs
-          input_start <- "${{ github.event.inputs.start_id }}"
-          input_end <- "${{ github.event.inputs.end_id }}"
-          skip_cached <- !as.logical("${{ github.event.inputs.force_rescrape }}")
-          if (is.na(skip_cached)) skip_cached <- TRUE
+          lookback <- as.integer("${{ github.event.inputs.lookback }}")
+          if (is.na(lookback)) lookback <- 20
 
-          # Auto-detect ID range if not provided
-          if (nzchar(input_start) && nzchar(input_end)) {
-            start_id <- as.integer(input_start)
-            end_id <- as.integer(input_end)
-            message(sprintf("Using manual ID range: %d to %d", start_id, end_id))
-          } else {
-            # Find max cached ID across all leagues
-            all_cached_ids <- c()
-            for (league in c("ENG", "ESP", "GER", "ITA", "FRA", "RUS")) {
-              for (season in 2014:2025) {
-                ids <- tryCatch(
-                  get_cached_understat_ids(league, season),
-                  error = function(e) character(0)
-                )
-                all_cached_ids <- c(all_cached_ids, as.integer(ids))
-              }
-            }
+          max_misses <- as.integer("${{ github.event.inputs.max_misses }}")
+          if (is.na(max_misses)) max_misses <- 50
 
-            if (length(all_cached_ids) > 0) {
-              max_cached <- max(all_cached_ids, na.rm = TRUE)
-              start_id <- max_cached + 1
-              end_id <- start_id + 499
-              message(sprintf("Auto-detected: max cached ID = %d", max_cached))
-              message(sprintf("Scraping ID range: %d to %d", start_id, end_id))
-            } else {
-              # First run - start from a known recent range
-              # 2024-25 season IDs are approximately 27000-29000+
-              start_id <- 28000
-              end_id <- 28499
-              message("No cached data found, starting fresh from ID 28000")
-            }
-          }
+          manifest_path <- file.path(getwd(), "data", "understat-manifest.parquet")
 
           cat("\n", strrep("=", 60), "\n")
-          cat("PANNA DAILY UNDERSTAT SCRAPE\n")
+          cat("PANNA SMART UNDERSTAT SCRAPE\n")
           cat(strrep("=", 60), "\n\n")
-          cat("ID Range:", start_id, "to", end_id, "\n")
-          cat("Skip cached:", skip_cached, "\n")
+          cat("Manifest path:", manifest_path, "\n")
+          cat("Lookback:", lookback, "IDs\n")
+          cat("Max misses per league:", max_misses, "\n")
           cat("Started:", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), "\n\n")
 
-          # Run bulk scrape with auto-detection
-          results <- bulk_scrape_understat(
-            start_id = start_id,
-            end_id = end_id,
+          # Run smart scraper with per-league tracking
+          results <- smart_scrape_understat(
+            manifest_path = manifest_path,
+            leagues = c("RUS", "ENG", "ESP", "FRA", "ITA", "GER"),
+            lookback = lookback,
+            max_misses = max_misses,
             delay = 3,
-            skip_cached = skip_cached,
             verbose = TRUE
           )
 
@@ -165,10 +181,17 @@ jobs:
           cat("SCRAPE SUMMARY\n")
           cat(strrep("=", 60), "\n")
           print(table(results$status))
+
           if (any(results$status == "success")) {
-            cat("\nLeague breakdown:\n")
+            cat("\nNew matches by league:\n")
             print(table(results$league[results$status == "success"]))
           }
+
+          # Show manifest stats
+          manifest <- load_understat_manifest(manifest_path)
+          cat("\nManifest totals by league:\n")
+          print(table(manifest$league))
+
           cat("\nFinished:", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), "\n")
         '
       shell: bash
@@ -200,7 +223,7 @@ jobs:
         '
       shell: bash
 
-    - name: Upload individual Understat parquet files to GitHub Releases
+    - name: Upload manifest to GitHub Releases
       run: |
         # Create release if it doesn't exist
         if ! gh release view understat-latest --repo peteowen1/pannadata >/dev/null 2>&1; then
@@ -208,10 +231,22 @@ jobs:
           gh release create understat-latest \
             --repo peteowen1/pannadata \
             --title "Understat Data (Latest)" \
-            --notes "Automated daily Understat data scrape. Individual parquet files for fast remote queries." \
+            --notes "Automated daily Understat data scrape with per-league tracking. Individual parquet files for fast remote queries." \
             --prerelease
         fi
 
+        # Upload manifest
+        if [ -f "data/understat-manifest.parquet" ]; then
+          echo "Uploading manifest..."
+          gh release upload understat-latest "data/understat-manifest.parquet" \
+            --repo peteowen1/pannadata \
+            --clobber
+        fi
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload consolidated Understat parquet files to GitHub Releases
+      run: |
         # Upload consolidated parquet files (understat_*.parquet)
         echo "Uploading consolidated Understat parquet files..."
         for f in data/consolidated/understat_*.parquet; do
@@ -270,7 +305,10 @@ jobs:
         echo "Daily Understat scrape completed successfully"
         echo "Check pannadata repo understat-latest release for updated data"
         echo ""
-        echo "Individual parquet files available for fast remote queries:"
+        echo "Manifest:"
+        ls -lh data/understat-manifest.parquet 2>/dev/null || echo "  (none)"
+        echo ""
+        echo "Consolidated parquet files:"
         ls -lh data/consolidated/understat_*.parquet 2>/dev/null || echo "  (none)"
         echo ""
         echo "Total Understat parquet files: $(find data/understat -name '*.parquet' 2>/dev/null | wc -l)"

--- a/scripts/understat/backfill_understat.R
+++ b/scripts/understat/backfill_understat.R
@@ -1,0 +1,301 @@
+#!/usr/bin/env Rscript
+#' Understat Historical Backfill Script
+#'
+#' Backfills missing Understat data for seasons 2020-2024 (IDs ~11000-28000).
+#' Designed to run in chunks to avoid timeouts and allow resumption.
+#'
+#' The full backfill (~17,000 IDs at 3s delay) takes ~14 hours.
+#' Recommended: Run in ~2000 ID chunks (about 1.5-2 hours each).
+#'
+#' Usage:
+#'   Rscript backfill_understat.R                    # Auto-detect next chunk
+#'   Rscript backfill_understat.R --start 15000 --end 17000  # Specific range
+#'   Rscript backfill_understat.R --chunk-size 1000  # Smaller chunks
+#'   Rscript backfill_understat.R --status           # Show progress only
+#'
+#' Progress is tracked in the manifest file, so you can stop and resume anytime.
+
+# Load panna from development
+devtools::load_all("panna")
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+# Full backfill range (2020-2024 data is roughly in this range)
+BACKFILL_START <- 11263   # After Russian 2019 data ends
+BACKFILL_END   <- 27999   # Before 2025 data starts
+
+# Default chunk size (IDs per run)
+DEFAULT_CHUNK_SIZE <- 2000
+
+# Request delay
+DELAY <- 3
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+#' Get backfill progress from manifest
+get_backfill_progress <- function(manifest_path) {
+  manifest <- load_understat_manifest(manifest_path)
+
+  if (nrow(manifest) == 0) {
+    return(list(
+      total_matches = 0,
+      backfill_matches = 0,
+      min_backfill_id = NA,
+      max_backfill_id = NA,
+      gaps = list()
+    ))
+  }
+
+  # Filter to backfill range
+  backfill_ids <- manifest$match_id[manifest$match_id >= BACKFILL_START &
+                                      manifest$match_id <= BACKFILL_END]
+
+  # Find gaps in coverage
+  if (length(backfill_ids) > 0) {
+    all_ids <- BACKFILL_START:BACKFILL_END
+    missing_ids <- setdiff(all_ids, backfill_ids)
+
+    # Group consecutive missing IDs into ranges
+    if (length(missing_ids) > 0) {
+      gaps <- list()
+      start <- missing_ids[1]
+      end <- missing_ids[1]
+
+      for (i in 2:length(missing_ids)) {
+        if (missing_ids[i] == end + 1) {
+          end <- missing_ids[i]
+        } else {
+          gaps[[length(gaps) + 1]] <- c(start, end)
+          start <- missing_ids[i]
+          end <- missing_ids[i]
+        }
+      }
+      gaps[[length(gaps) + 1]] <- c(start, end)
+    } else {
+      gaps <- list()
+    }
+  } else {
+    gaps <- list(c(BACKFILL_START, BACKFILL_END))
+  }
+
+  list(
+    total_matches = nrow(manifest),
+    backfill_matches = length(backfill_ids),
+    min_backfill_id = if (length(backfill_ids) > 0) min(backfill_ids) else NA,
+    max_backfill_id = if (length(backfill_ids) > 0) max(backfill_ids) else NA,
+    gaps = gaps
+  )
+}
+
+
+#' Print backfill status
+print_backfill_status <- function(manifest_path) {
+  progress <- get_backfill_progress(manifest_path)
+
+  cat("\n", strrep("=", 60), "\n")
+  cat("UNDERSTAT BACKFILL STATUS\n")
+  cat(strrep("=", 60), "\n\n")
+
+  cat("Backfill range:", BACKFILL_START, "to", BACKFILL_END, "\n")
+  cat("Total IDs in range:", BACKFILL_END - BACKFILL_START + 1, "\n\n")
+
+  cat("Manifest stats:\n")
+  cat("  Total matches:", progress$total_matches, "\n")
+  cat("  Backfill matches:", progress$backfill_matches, "\n")
+
+  if (!is.na(progress$min_backfill_id)) {
+    cat("  Min backfill ID:", progress$min_backfill_id, "\n")
+    cat("  Max backfill ID:", progress$max_backfill_id, "\n")
+  }
+
+  cat("\nGaps in coverage:\n")
+  if (length(progress$gaps) == 0) {
+    cat("  None! Backfill complete.\n")
+  } else if (length(progress$gaps) <= 10) {
+    for (gap in progress$gaps) {
+      cat(sprintf("  %d - %d (%d IDs)\n", gap[1], gap[2], gap[2] - gap[1] + 1))
+    }
+  } else {
+    # Show first 5 and last 5 gaps
+    cat(sprintf("  Found %d gaps. First 5:\n", length(progress$gaps)))
+    for (gap in progress$gaps[1:5]) {
+      cat(sprintf("    %d - %d (%d IDs)\n", gap[1], gap[2], gap[2] - gap[1] + 1))
+    }
+    cat("  ...\n  Last 5:\n")
+    for (gap in tail(progress$gaps, 5)) {
+      cat(sprintf("    %d - %d (%d IDs)\n", gap[1], gap[2], gap[2] - gap[1] + 1))
+    }
+  }
+
+  # Estimate remaining time
+  if (length(progress$gaps) > 0) {
+    total_missing <- sum(sapply(progress$gaps, function(g) g[2] - g[1] + 1))
+    est_hours <- (total_missing * DELAY) / 3600
+    cat(sprintf("\nEstimated time remaining: %.1f hours (%d IDs at %ds delay)\n",
+                est_hours, total_missing, DELAY))
+  }
+
+  cat("\n")
+}
+
+
+#' Get next chunk to process
+get_next_chunk <- function(manifest_path, chunk_size) {
+  progress <- get_backfill_progress(manifest_path)
+
+  if (length(progress$gaps) == 0) {
+    return(NULL)  # Backfill complete
+  }
+
+  # Get the first gap
+  first_gap <- progress$gaps[[1]]
+  start_id <- first_gap[1]
+  end_id <- min(first_gap[2], start_id + chunk_size - 1)
+
+  c(start_id, end_id)
+}
+
+
+# =============================================================================
+# Main Backfill Function
+# =============================================================================
+
+run_backfill <- function(manifest_path, start_id = NULL, end_id = NULL,
+                          chunk_size = DEFAULT_CHUNK_SIZE, status_only = FALSE) {
+
+  # Show status
+  print_backfill_status(manifest_path)
+
+  if (status_only) {
+    return(invisible(NULL))
+  }
+
+  # Determine chunk to process
+  if (is.null(start_id) || is.null(end_id)) {
+    chunk <- get_next_chunk(manifest_path, chunk_size)
+    if (is.null(chunk)) {
+      cat("Backfill complete! No more gaps to fill.\n")
+      return(invisible(NULL))
+    }
+    start_id <- chunk[1]
+    end_id <- chunk[2]
+  }
+
+  # Validate range
+  if (start_id > end_id) {
+    stop("start_id must be <= end_id")
+  }
+
+  n_ids <- end_id - start_id + 1
+  est_time <- (n_ids * DELAY) / 60
+
+  cat("\n", strrep("=", 60), "\n")
+  cat("STARTING BACKFILL CHUNK\n")
+  cat(strrep("=", 60), "\n\n")
+  cat("Range:", start_id, "to", end_id, sprintf("(%d IDs)\n", n_ids))
+  cat("Estimated time:", sprintf("%.0f minutes\n", est_time))
+  cat("Started:", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), "\n\n")
+
+  # Run bulk scrape
+  results <- bulk_scrape_understat(
+    start_id = start_id,
+    end_id = end_id,
+    delay = DELAY,
+    skip_cached = TRUE,  # Skip if already in cache (from prior runs)
+    verbose = TRUE
+  )
+
+  # Update manifest with new matches
+  manifest <- load_understat_manifest(manifest_path)
+
+  success_results <- results[results$status == "success", ]
+  if (nrow(success_results) > 0) {
+    new_entries <- data.frame(
+      match_id = as.integer(success_results$match_id),
+      league = success_results$league,
+      season = success_results$season,
+      scraped_at = Sys.time(),
+      stringsAsFactors = FALSE
+    )
+
+    # Add to manifest (avoiding duplicates)
+    new_entries <- new_entries[!new_entries$match_id %in% manifest$match_id, ]
+    if (nrow(new_entries) > 0) {
+      manifest <- rbind(manifest, new_entries)
+      save_understat_manifest(manifest, manifest_path)
+    }
+  }
+
+  # Summary
+  cat("\n", strrep("=", 60), "\n")
+  cat("CHUNK COMPLETE\n")
+  cat(strrep("=", 60), "\n")
+  print(table(results$status))
+
+  if (any(results$status == "success")) {
+    cat("\nNew matches by league:\n")
+    print(table(results$league[results$status == "success"]))
+
+    cat("\nNew matches by season:\n")
+    print(table(results$season[results$status == "success"]))
+  }
+
+  cat("\nFinished:", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), "\n")
+
+  # Show updated status
+  print_backfill_status(manifest_path)
+
+  invisible(results)
+}
+
+
+# =============================================================================
+# CLI Entry Point
+# =============================================================================
+
+if (!interactive()) {
+  args <- commandArgs(trailingOnly = TRUE)
+
+  # Parse arguments
+  start_id <- NULL
+  end_id <- NULL
+  chunk_size <- DEFAULT_CHUNK_SIZE
+  status_only <- FALSE
+
+  i <- 1
+  while (i <= length(args)) {
+    if (args[i] == "--start" && i < length(args)) {
+      start_id <- as.integer(args[i + 1])
+      i <- i + 2
+    } else if (args[i] == "--end" && i < length(args)) {
+      end_id <- as.integer(args[i + 1])
+      i <- i + 2
+    } else if (args[i] == "--chunk-size" && i < length(args)) {
+      chunk_size <- as.integer(args[i + 1])
+      i <- i + 2
+    } else if (args[i] == "--status") {
+      status_only <- TRUE
+      i <- i + 1
+    } else {
+      i <- i + 1
+    }
+  }
+
+  # Set pannadata directory (assumes running from pannaverse root)
+  pannadata_dir("pannadata/data")
+
+  # Manifest path
+  manifest_path <- file.path(pannadata_dir(), "understat-manifest.parquet")
+
+  run_backfill(
+    manifest_path = manifest_path,
+    start_id = start_id,
+    end_id = end_id,
+    chunk_size = chunk_size,
+    status_only = status_only
+  )
+}

--- a/scripts/understat/init_backfill.R
+++ b/scripts/understat/init_backfill.R
@@ -1,0 +1,82 @@
+#!/usr/bin/env Rscript
+#' Initialize Understat Backfill
+#'
+#' Downloads existing data from GitHub Releases and builds the manifest.
+#' Run this once before starting the backfill process.
+#'
+#' Usage:
+#'   cd pannaverse
+#'   Rscript pannadata/scripts/understat/init_backfill.R
+
+# Load panna from development
+devtools::load_all("panna")
+
+# Set pannadata directory
+pannadata_dir("pannadata/data")
+
+cat("\n", strrep("=", 60), "\n")
+cat("INITIALIZING UNDERSTAT BACKFILL\n")
+cat(strrep("=", 60), "\n\n")
+
+cat("Data directory:", pannadata_dir(), "\n\n")
+
+# Step 1: Download existing data
+cat("Step 1: Downloading existing Understat data from GitHub Releases...\n")
+tryCatch({
+  pb_download_source(
+    source_type = "understat",
+    repo = "peteowen1/pannadata",
+    dest = pannadata_dir(),
+    verbose = TRUE
+  )
+  cat("Downloaded existing data.\n\n")
+}, error = function(e) {
+  cat("No existing data or download failed:", e$message, "\n\n")
+})
+
+# Step 2: Build manifest from cached data
+manifest_path <- file.path(pannadata_dir(), "understat-manifest.parquet")
+
+cat("Step 2: Building manifest from cached data...\n")
+manifest <- build_understat_manifest_from_cache(pannadata_dir())
+
+if (nrow(manifest) > 0) {
+  save_understat_manifest(manifest, manifest_path)
+  cat(sprintf("Built manifest with %d matches.\n", nrow(manifest)))
+
+  cat("\nLeague breakdown:\n")
+  print(table(manifest$league))
+
+  cat("\nSeason breakdown:\n")
+  print(table(manifest$season))
+
+  # Show ID ranges
+  cat("\nID ranges per league:\n")
+  for (lg in unique(manifest$league)) {
+    ids <- manifest$match_id[manifest$league == lg]
+    cat(sprintf("  %s: %d - %d (n=%d)\n", lg, min(ids), max(ids), length(ids)))
+  }
+} else {
+  cat("No existing data found. Starting fresh.\n")
+  # Create empty manifest
+  save_understat_manifest(
+    data.frame(
+      match_id = integer(0),
+      league = character(0),
+      season = character(0),
+      scraped_at = as.POSIXct(character(0)),
+      stringsAsFactors = FALSE
+    ),
+    manifest_path
+  )
+}
+
+cat("\n", strrep("=", 60), "\n")
+cat("INITIALIZATION COMPLETE\n")
+cat(strrep("=", 60), "\n\n")
+
+cat("Next steps:\n")
+cat("  1. Check backfill status:  Rscript pannadata/scripts/understat/backfill_understat.R --status\n")
+cat("  2. Run first chunk:        Rscript pannadata/scripts/understat/backfill_understat.R\n")
+cat("  3. Or specific range:      Rscript pannadata/scripts/understat/backfill_understat.R --start 15000 --end 17000\n")
+cat("\n")

--- a/scripts/understat/scrape_understat.R
+++ b/scripts/understat/scrape_understat.R
@@ -1,8 +1,9 @@
 #!/usr/bin/env Rscript
-#' Understat Daily Scraper
+#' Understat Smart Scraper
 #'
-#' Scrapes match data from Understat using numeric match IDs. Unlike FBref,
-#' Understat doesn't block GitHub Actions, so this can run via workflow.
+#' Scrapes match data from Understat using per-league ID tracking. Unlike the
+#' old approach that scanned forward from a global max ID, this scraper tracks
+#' each league independently to handle Understat's interleaved ID structure.
 #'
 #' Understat data includes:
 #'   - xGChain: Expected goals from possession chains
@@ -10,7 +11,7 @@
 #'   - Shot-level xG with coordinates
 #'
 #' Data flow:
-#'   Understat website -> panna::bulk_scrape_understat() -> parquet files
+#'   Understat website -> panna::smart_scrape_understat() -> parquet files
 #'   parquet files -> panna::build_consolidated_understat_parquet() -> consolidated
 #'   consolidated -> panna::pb_upload_source() -> GitHub Releases
 #'
@@ -18,14 +19,17 @@
 #'   data/understat/roster/{league}/{season}.parquet
 #'   data/understat/shots/{league}/{season}.parquet
 #'   data/understat/metadata/{league}/{season}.parquet
+#'   data/understat-manifest.parquet (tracks all scraped matches)
 #'
 #' Usage:
-#'   Rscript scrape_understat.R                          # Auto-detect ID range
-#'   Rscript scrape_understat.R --start 28000 --end 28500  # Specific range
-#'   Rscript scrape_understat.R --upload                 # Upload after scrape
+#'   Rscript scrape_understat.R                       # Auto-detect, default params
+#'   Rscript scrape_understat.R --lookback 50         # Look back 50 IDs from max
+#'   Rscript scrape_understat.R --max-misses 100      # Stop after 100 consecutive misses
+#'   Rscript scrape_understat.R --upload              # Upload after scrape
+#'   Rscript scrape_understat.R --rebuild-manifest    # Rebuild manifest from cache
 #'
-#' Note: Match IDs are sequential integers. The scraper auto-detects the
-#' latest cached ID and scrapes forward from there.
+#' Note: Match IDs are interleaved across leagues. Each league occupies a distinct
+#' ID band (~200-300 IDs apart). The scraper processes each league independently.
 
 library(panna)
 
@@ -36,76 +40,57 @@ library(panna)
 # Request delay (seconds between Understat requests)
 DELAY <- 3
 
-# Leagues covered by Understat
-LEAGUES <- c("ENG", "ESP", "GER", "ITA", "FRA", "RUS")
-
-# =============================================================================
-# Helper Functions
-# =============================================================================
-
-#' Find the maximum cached Understat match ID across all leagues
-find_max_cached_id <- function() {
-  all_cached_ids <- c()
-
-  for (league in LEAGUES) {
-    for (season in 2014:2025) {
-      ids <- tryCatch(
-        get_cached_understat_ids(league, season),
-        error = function(e) character(0)
-      )
-      all_cached_ids <- c(all_cached_ids, as.integer(ids))
-    }
-  }
-
-  if (length(all_cached_ids) > 0) {
-    max(all_cached_ids, na.rm = TRUE)
-  } else {
-    NULL
-  }
-}
+# Leagues covered by Understat (ordered by ID range: lowest to highest)
+LEAGUES <- c("RUS", "ENG", "ESP", "FRA", "ITA", "GER")
 
 # =============================================================================
 # Main Scraper Function
 # =============================================================================
 
-scrape_understat <- function(start_id = NULL, end_id = NULL,
-                              skip_cached = TRUE, upload_after = FALSE) {
+scrape_understat_smart <- function(manifest_path,
+                                    lookback = 20,
+                                    max_misses = 50,
+                                    upload_after = FALSE,
+                                    rebuild_manifest = FALSE) {
 
   # -------------------------------------------------------------------------
-  # Auto-detect ID range if not provided
+  # Build or load manifest
   # -------------------------------------------------------------------------
-  if (is.null(start_id) || is.null(end_id)) {
-    max_cached <- find_max_cached_id()
+  if (rebuild_manifest || !file.exists(manifest_path)) {
+    cat("Building manifest from existing cache...\n")
+    manifest <- build_understat_manifest_from_cache(pannadata_dir())
 
-    if (!is.null(max_cached)) {
-      start_id <- max_cached + 1
-      end_id <- start_id + 499
-      message(sprintf("Auto-detected: max cached ID = %d", max_cached))
-      message(sprintf("Scraping ID range: %d to %d", start_id, end_id))
+    if (nrow(manifest) > 0) {
+      save_understat_manifest(manifest, manifest_path)
+      cat(sprintf("Built manifest with %d matches\n", nrow(manifest)))
+      cat("\nLeague breakdown:\n")
+      print(table(manifest$league))
     } else {
-      # First run - start from a known recent range
-      # 2024-25 season IDs are approximately 27000-29000+
-      start_id <- 28000
-      end_id <- 28499
-      message("No cached data found, starting fresh from ID 28000")
+      cat("No existing data to build manifest from\n")
     }
+  } else {
+    manifest <- load_understat_manifest(manifest_path)
+    cat(sprintf("Loaded existing manifest with %d matches\n", nrow(manifest)))
   }
 
+  # -------------------------------------------------------------------------
+  # Run smart scraper
+  # -------------------------------------------------------------------------
   cat("\n", strrep("=", 60), "\n")
-  cat("PANNA DAILY UNDERSTAT SCRAPE\n")
+  cat("PANNA SMART UNDERSTAT SCRAPE\n")
   cat(strrep("=", 60), "\n\n")
-  cat("ID Range:", start_id, "to", end_id, "\n")
-  cat("Skip cached:", skip_cached, "\n")
+  cat("Manifest path:", manifest_path, "\n")
+  cat("Lookback:", lookback, "IDs\n")
+  cat("Max misses per league:", max_misses, "\n")
+  cat("Delay:", DELAY, "seconds\n")
   cat("Started:", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), "\n\n")
 
-  # -------------------------------------------------------------------------
-  # Run bulk scrape
-  # -------------------------------------------------------------------------
-  results <- bulk_scrape_understat(
-    start_id = start_id,
-    end_id = end_id,
+  results <- smart_scrape_understat(
+    manifest_path = manifest_path,
+    leagues = LEAGUES,
+    lookback = lookback,
+    max_misses = max_misses,
     delay = DELAY,
-    skip_cached = skip_cached,
     verbose = TRUE
   )
 
@@ -118,9 +103,14 @@ scrape_understat <- function(start_id = NULL, end_id = NULL,
   print(table(results$status))
 
   if (any(results$status == "success")) {
-    cat("\nLeague breakdown:\n")
+    cat("\nNew matches by league:\n")
     print(table(results$league[results$status == "success"]))
   }
+
+  # Show manifest stats
+  manifest <- load_understat_manifest(manifest_path)
+  cat("\nManifest totals by league:\n")
+  print(table(manifest$league))
 
   cat("\nFinished:", format(Sys.time(), "%Y-%m-%d %H:%M:%S"), "\n")
 
@@ -175,24 +165,24 @@ if (!interactive()) {
   args <- commandArgs(trailingOnly = TRUE)
 
   # Parse arguments
-  start_id <- NULL
-  end_id <- NULL
-  skip_cached <- TRUE
+  lookback <- 20
+  max_misses <- 50
   upload_after <- FALSE
+  rebuild_manifest <- FALSE
 
   i <- 1
   while (i <= length(args)) {
-    if (args[i] == "--start" && i < length(args)) {
-      start_id <- as.integer(args[i + 1])
+    if (args[i] == "--lookback" && i < length(args)) {
+      lookback <- as.integer(args[i + 1])
       i <- i + 2
-    } else if (args[i] == "--end" && i < length(args)) {
-      end_id <- as.integer(args[i + 1])
+    } else if (args[i] == "--max-misses" && i < length(args)) {
+      max_misses <- as.integer(args[i + 1])
       i <- i + 2
-    } else if (args[i] == "--force") {
-      skip_cached <- FALSE
-      i <- i + 1
     } else if (args[i] == "--upload") {
       upload_after <- TRUE
+      i <- i + 1
+    } else if (args[i] == "--rebuild-manifest") {
+      rebuild_manifest <- TRUE
       i <- i + 1
     } else {
       i <- i + 1
@@ -204,10 +194,14 @@ if (!interactive()) {
   data_dir <- file.path(dirname(dirname(script_dir)), "data")
   pannadata_dir(data_dir)
 
-  scrape_understat(
-    start_id = start_id,
-    end_id = end_id,
-    skip_cached = skip_cached,
-    upload_after = upload_after
+  # Manifest path
+  manifest_path <- file.path(data_dir, "understat-manifest.parquet")
+
+  scrape_understat_smart(
+    manifest_path = manifest_path,
+    lookback = lookback,
+    max_misses = max_misses,
+    upload_after = upload_after,
+    rebuild_manifest = rebuild_manifest
   )
 }


### PR DESCRIPTION
## Summary
- Replace naive sequential ID scan with smart per-league manifest-based scraper (`smart_scrape_understat()`)
- Workflow now downloads/builds manifest from GitHub Releases and uploads it after each run
- Add backfill scripts for historical data (IDs 11263-27999) with chunked resume support

## Test plan
- [ ] Verify `daily-understat-scrape.yml` workflow runs successfully on dispatch
- [ ] Confirm manifest parquet is uploaded to `understat-latest` release
- [ ] Test backfill script with `--status` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)