### PR TITLE
Harden pipeline, add data catalog, rewrite docs

### DIFF
--- a/.github/workflows/daily-opta-scrape.yml
+++ b/.github/workflows/daily-opta-scrape.yml
@@ -102,8 +102,14 @@ jobs:
         PARQUET_COUNT=$(find opta -name "*.parquet" 2>/dev/null | wc -l)
         echo "Total parquet files: $PARQUET_COUNT"
         if [ "$PARQUET_COUNT" -eq 0 ]; then
-          echo "No parquet files to consolidate"
-          exit 0
+          # Distinguish "no new data" from "scraper crashed"
+          if [ -f "../scripts/opta/data/scrape_summary.json" ]; then
+            echo "No new parquet files, but scraper ran successfully (no new matches)"
+            exit 0
+          else
+            echo "ERROR: No parquet files AND no scrape summary - scraper may have crashed"
+            exit 1
+          fi
         fi
         python ../scripts/opta/consolidate_opta.py
 

--- a/.github/workflows/daily-opta-scrape.yml
+++ b/.github/workflows/daily-opta-scrape.yml
@@ -133,6 +133,12 @@ jobs:
           [ -f "$f" ] && gh release upload opta-latest "$f" --clobber && echo "Uploaded $(basename $f)"
         done
 
+        # Upload data catalog
+        if [ -f "opta/opta-catalog.json" ]; then
+          gh release upload opta-latest opta/opta-catalog.json --clobber
+          echo "Uploaded opta-catalog.json"
+        fi
+
         # Upload per-league events files
         if [ -d "opta/events_consolidated" ]; then
           for f in opta/events_consolidated/events_*.parquet; do

--- a/.github/workflows/daily-opta-scrape.yml
+++ b/.github/workflows/daily-opta-scrape.yml
@@ -84,13 +84,17 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Run Opta scraper
+      env:
+        INPUT_LEAGUES: ${{ github.event.inputs.leagues }}
+        INPUT_RECENT: ${{ github.event.inputs.recent || 1 }}
+        INPUT_FORCE: ${{ github.event.inputs.force_rescrape }}
       run: |
         cd scripts/opta
-        ARGS="--recent ${{ github.event.inputs.recent || 1 }}"
-        if [ -n "${{ github.event.inputs.leagues }}" ]; then
-          ARGS="$ARGS --leagues ${{ github.event.inputs.leagues }}"
+        ARGS="--recent $INPUT_RECENT"
+        if [ -n "$INPUT_LEAGUES" ]; then
+          ARGS="$ARGS --leagues $INPUT_LEAGUES"
         fi
-        if [ "${{ github.event.inputs.force_rescrape }}" = "true" ]; then
+        if [ "$INPUT_FORCE" = "true" ]; then
           ARGS="$ARGS --force"
         fi
         echo "Running: python scrape_opta.py $ARGS"

--- a/README.md
+++ b/README.md
@@ -8,23 +8,25 @@ Data repository for the pannaverse ecosystem. Contains cached football match dat
 
 15 leagues with 263 columns per player match, plus event-level data with x/y coordinates.
 
-| League | Code | Seasons | Data Types |
-|--------|------|---------|------------|
-| Premier League | EPL | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| La Liga | La_Liga | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Bundesliga | Bundesliga | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Serie A | Serie_A | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Ligue 1 | Ligue_1 | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Eredivisie | NED | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Primeira Liga | POR | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Super Lig | TUR | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Championship | ENG2 | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Scottish Premiership | SCO | 2019-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Champions League | UCL | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Europa League | UEL | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Conference League | UECL | 2021-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| World Cup | WC | 2014, 2018 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
-| Euros | EURO | 2016, 2024 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| League | Opta Code | R Alias | Seasons | Data Types |
+|--------|-----------|---------|---------|------------|
+| Premier League | EPL | ENG | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| La Liga | La_Liga | ESP | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Bundesliga | Bundesliga | GER | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Serie A | Serie_A | ITA | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Ligue 1 | Ligue_1 | FRA | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Eredivisie | Eredivisie | NED | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Primeira Liga | Primeira_Liga | POR | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Super Lig | Super_Lig | TUR | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Championship | Championship | ENG2 | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Scottish Premiership | Scottish_Premiership | SCO | 2019-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Champions League | UCL | UCL | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Europa League | UEL | UEL | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Conference League | Conference_League | UECL | 2021-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| World Cup | World_Cup | WC | 2014, 2018 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Euros | UEFA_Euros | EURO | 2016, 2024 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+
+> **Note:** The "Opta Code" is used in filesystem paths and raw data. The "R Alias" is the shorthand accepted by `panna` R package functions like `load_opta_stats()`. Both work interchangeably in the R API.
 
 ### Understat
 
@@ -58,8 +60,7 @@ data/
 ├── opta/
 │   ├── {data_type}/
 │   │   └── {league}/
-│   │       └── {season}/
-│   │           └── {match_id}.rds          # Individual match files
+│   │       └── {season}.parquet            # Per-season parquet files
 │   ├── fixtures/
 │   │   └── {league}/
 │   │       └── {season}.parquet            # Fixture parquets (all match statuses)
@@ -132,7 +133,7 @@ fixtures <- load_opta_fixtures("EPL")
 xmetrics <- load_opta_xmetrics("EPL", "2024-2025")
 
 # Load Understat data
-roster <- load_understat_roster("EPL", "2024")
+roster <- load_understat_roster("ENG", "2024")
 
 # Load FBref data
 summary <- load_summary("ENG", "2024-2025")

--- a/README.md
+++ b/README.md
@@ -1,10 +1,43 @@
 # pannadata
 
-Data repository for the pannaverse ecosystem. Contains cached football match data from FBref, Opta, and Understat.
+Data repository for the pannaverse ecosystem. Contains cached football match data from Opta, Understat, and FBref.
 
 ## Data Coverage
 
-### FBref (Primary Source)
+### Opta (Primary Source)
+
+15 leagues with 263 columns per player match, plus event-level data with x/y coordinates.
+
+| League | Code | Seasons | Data Types |
+|--------|------|---------|------------|
+| Premier League | EPL | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| La Liga | La_Liga | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Bundesliga | Bundesliga | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Serie A | Serie_A | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Ligue 1 | Ligue_1 | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Eredivisie | NED | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Primeira Liga | POR | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Super Lig | TUR | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Championship | ENG2 | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Scottish Premiership | SCO | 2019-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Champions League | UCL | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Europa League | UEL | 2013-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Conference League | UECL | 2021-2025 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| World Cup | WC | 2014, 2018 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+| Euros | EURO | 2016, 2024 | player_stats, shots, shot_events, events, match_events, lineups, fixtures |
+
+### Understat
+
+| League | Seasons | Features |
+|--------|---------|----------|
+| EPL | 2014-2024 | xGChain, xGBuildup |
+| La_Liga | 2014-2024 | xGChain, xGBuildup |
+| Bundesliga | 2014-2024 | xGChain, xGBuildup |
+| Serie_A | 2014-2024 | xGChain, xGBuildup |
+| Ligue_1 | 2014-2024 | xGChain, xGBuildup |
+| RFPL | 2014-2024 | xGChain, xGBuildup |
+
+### FBref
 
 | League | Seasons | xG Model |
 |--------|---------|----------|
@@ -18,42 +51,52 @@ Data repository for the pannaverse ecosystem. Contains cached football match dat
 | Domestic Cups | Various | StatsBomb |
 | International | Various | StatsBomb |
 
-### Opta
-
-| League | Seasons | Columns |
-|--------|---------|---------|
-| EPL | 2010-2025 | 271 |
-| La_Liga | 2010-2025 | 271 |
-| Bundesliga | 2010-2025 | 271 |
-| Serie_A | 2010-2025 | 271 |
-| Ligue_1 | 2010-2025 | 271 |
-
-### Understat
-
-| League | Seasons | Features |
-|--------|---------|----------|
-| EPL | 2014-2024 | xGChain, xGBuildup |
-| La_Liga | 2014-2024 | xGChain, xGBuildup |
-| Bundesliga | 2014-2024 | xGChain, xGBuildup |
-| Serie_A | 2014-2024 | xGChain, xGBuildup |
-| Ligue_1 | 2014-2024 | xGChain, xGBuildup |
-| RFPL | 2014-2024 | xGChain, xGBuildup |
-
 ## Data Structure
 
 ```
 data/
+├── opta/
+│   ├── {data_type}/
+│   │   └── {league}/
+│   │       └── {season}/
+│   │           └── {match_id}.rds          # Individual match files
+│   ├── fixtures/
+│   │   └── {league}/
+│   │       └── {season}.parquet            # Fixture parquets (all match statuses)
+│   ├── xmetrics/
+│   │   └── {league}/
+│   │       └── {season}.parquet            # Pre-computed xG/xA/xPass per player
+│   ├── models/
+│   │   ├── xg_model.rds                    # Pre-trained xG model
+│   │   ├── xpass_model.rds                 # Pre-trained xPass model
+│   │   └── epv_model.rds                   # Pre-trained EPV model
+│   ├── opta_player_stats.parquet           # Consolidated player stats (all leagues)
+│   ├── opta_shots.parquet                  # Consolidated shots (all leagues)
+│   └── opta_fixtures.parquet               # Consolidated fixtures (all leagues)
+├── understat/
+│   └── {tabletype}/{league}/{season}.parquet
 ├── fbref/
 │   ├── {tabletype}/
 │   │   └── {league}/
 │   │       └── {season}/
-│   │           └── {match_id}.rds
+│   │           └── {match_id}.rds          # Individual match files
 │   └── {tabletype}/{league}/{season}.parquet
-├── opta/
-│   └── {league}/{season}/{match_id}.rds
-└── understat/
-    └── {tabletype}/{league}/{season}.parquet
+└── metadata/
+    └── {league}/
+        └── {season}/                       # Match metadata
 ```
+
+### Opta Data Types
+
+| Type | Description | Key Columns |
+|------|-------------|-------------|
+| `player_stats` | Per-match player statistics | 263 columns: goals, assists, passes, tackles, etc. |
+| `shots` | Shot data per match | shot location, body part, outcome |
+| `shot_events` | Individual shots with coordinates | x, y, xG, player, minute |
+| `events` | Goals, cards, substitutions | event type, minute, player |
+| `match_events` | All events with x/y coordinates | SPADL-ready, used for EPV |
+| `lineups` | Starting XI and substitutions | player, position, minutes |
+| `fixtures` | Match fixtures and results | date, teams, score, status |
 
 ### FBref Table Types
 
@@ -76,36 +119,50 @@ This data is accessed via the `panna` package:
 library(panna)
 
 # Download data (first time)
-pb_download_source("fbref")
 pb_download_source("opta")
 pb_download_source("understat")
+pb_download_source("fbref")
+
+# Load Opta data (primary)
+opta_stats <- load_opta_stats("EPL", "2024-2025")
+opta_shots <- load_opta_shots("EPL", "2024-2025")
+match_events <- load_opta_match_events("EPL", "2024-2025")
+lineups <- load_opta_lineups("EPL", "2024-2025")
+fixtures <- load_opta_fixtures("EPL")
+xmetrics <- load_opta_xmetrics("EPL", "2024-2025")
+
+# Load Understat data
+roster <- load_understat_roster("EPL", "2024")
 
 # Load FBref data
 summary <- load_summary("ENG", "2024-2025")
 passing <- load_passing("ENG", "2024-2025")
 shots <- load_shots()
-
-# Load Opta data
-opta_stats <- load_opta_stats("EPL", "2024-2025")
-
-# Load Understat data
-roster <- load_understat_roster("EPL", "2024")
 ```
 
 ## Data Storage
 
 - **Local**: `data/` folder (gitignored, too large for git)
-- **Remote**: GitHub Releases at tag `latest`
-- **Format**: RDS for individual matches, Parquet for bulk storage
+- **Remote**: GitHub Releases (tag-based archives)
+- **Format**: RDS for individual matches, Parquet for bulk storage and consolidated files
+
+### GitHub Release Tags
+
+| Release Tag | Contents |
+|-------------|----------|
+| opta-latest | Consolidated Opta files (player_stats, shots, fixtures) |
+| fbref-latest | FBref parquet archives |
+| understat-latest | Understat parquet archives |
+| epv-models | Pre-trained xG, xPass, EPV models |
 
 ## Syncing Data
 
 ```r
 # Download from GitHub Releases
-panna::pb_download_source("fbref")
-panna::pb_download_source("opta")
-panna::pb_download_source("understat")
-panna::pb_download_source("all")  # Download everything
+panna::pb_download_source("opta")      # Download Opta data
+panna::pb_download_source("understat") # Download Understat data
+panna::pb_download_source("fbref")     # Download FBref data
+panna::pb_download_source("all")       # Download everything
 
 # Upload local data to GitHub Releases
 panna::pb_upload_parquet(repo = "peteowen1/pannadata", tag = "latest")

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ data/
 |------|-------------|-------------|
 | `player_stats` | Per-match player statistics | 263 columns: goals, assists, passes, tackles, etc. |
 | `shots` | Shot data per match | shot location, body part, outcome |
-| `shot_events` | Individual shots with coordinates | x, y, xG, player, minute |
+| `shot_events` | Individual shots with coordinates | x, y, type_id, body_part, minute |
 | `events` | Goals, cards, substitutions | event type, minute, player |
 | `match_events` | All events with x/y coordinates | SPADL-ready, used for EPV |
 | `lineups` | Starting XI and substitutions | player, position, minutes |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,9 +7,9 @@ the panna rating system.
 
 | Source | Language | Runs On | Schedule | Coverage |
 |--------|----------|---------|----------|----------|
-| [FBref](fbref/) | R | Oracle VM | 6 AM UTC | Big 5 + cups + international |
-| [Opta](opta/) | Python | GitHub Actions | 5 AM UTC | Big 5 leagues (2010+) |
+| [Opta](opta/) | Python | GitHub Actions | 5 AM UTC | 15 leagues (2013+) |
 | [Understat](understat/) | R | GitHub Actions | 7 AM UTC | Big 5 + Russia |
+| [FBref](fbref/) | R | Oracle VM | 6 AM UTC | Big 5 + cups + international |
 
 ## Why Different Environments?
 
@@ -48,19 +48,19 @@ data/
 │   ├── passing/
 │   ├── defense/
 │   └── ...
-├── opta/            # Opta data (parquet only)
+├── opta/            # Opta data (RDS + parquet)
 │   ├── player_stats/
 │   ├── events/
 │   ├── lineups/
-│   └── ...
+│   ├── opta_player_stats.parquet   # Consolidated
+│   ├── opta_shots.parquet          # Consolidated
+│   └── opta_fixtures.parquet       # Consolidated
 ├── understat/       # Understat data (parquet only)
 │   ├── roster/
 │   ├── shots/
-│   └── metadata/
-└── consolidated/    # Combined files for fast queries
-    ├── summary.parquet
-    ├── opta_player_stats.parquet
-    └── understat_roster.parquet
+│   ├── metadata/
+│   ├── understat_roster.parquet    # Consolidated
+│   └── understat_shots.parquet     # Consolidated
 ```
 
 ## GitHub Actions Workflows

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,7 +28,7 @@ Rscript scrape_fbref.R
 ```bash
 cd pannadata/scripts/opta
 pip install -r requirements.txt
-python scrape_big5.py
+python scrape_opta.py
 ```
 
 ### Understat
@@ -102,5 +102,5 @@ pb_download_source("understat")
 - [FBref README](fbref/README.md) - FBref scraper details
 - [Opta README](opta/README.md) - Opta scraper details
 - [Understat README](understat/README.md) - Understat scraper details
-- [pannadata CLAUDE.md](../CLAUDE.md) - Repository overview
+- [pannadata README](../README.md) - Repository overview
 - [panna package](../../panna/) - R package for data loading and analysis

--- a/scripts/opta/build_manifest.py
+++ b/scripts/opta/build_manifest.py
@@ -63,7 +63,7 @@ def build_manifest(opta_dir: str = "../../data/opta", output_path: str = None):
                     for mid in match_ids:
                         table_match_ids[table_type].add((mid, competition, season))
 
-                except Exception as e:
+                except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
                     print(f"  Warning: Error reading {parquet_file}: {e}")
 
     print(f"Found matches by table type:")

--- a/scripts/opta/competition_metadata.py
+++ b/scripts/opta/competition_metadata.py
@@ -152,6 +152,9 @@ PANNA_ALIASES = {
     "TUR": "Super_Lig",
     "ENG2": "Championship",
     "SCO": "Scottish_Premiership",
+    "UECL": "Conference_League",
+    "WC": "World_Cup",
+    "EURO": "UEFA_Euros",
 }
 
 

--- a/scripts/opta/competition_metadata.py
+++ b/scripts/opta/competition_metadata.py
@@ -1,0 +1,167 @@
+"""
+Competition metadata for Opta data catalog.
+
+Maps Opta competition codes (from seasons.json) to human-readable metadata.
+Unmapped codes get auto-generated names by humanizing underscored keys.
+"""
+
+# Mapping from seasons.json competition codes to metadata
+COMPETITION_METADATA = {
+    # Big 5 European Leagues
+    "EPL": {"name": "English Premier League", "country": "England", "type": "league", "tier": 1},
+    "La_Liga": {"name": "La Liga", "country": "Spain", "type": "league", "tier": 1},
+    "Bundesliga": {"name": "Bundesliga", "country": "Germany", "type": "league", "tier": 1},
+    "Serie_A": {"name": "Serie A", "country": "Italy", "type": "league", "tier": 1},
+    "Ligue_1": {"name": "Ligue 1", "country": "France", "type": "league", "tier": 1},
+
+    # Extended European Leagues
+    "Eredivisie": {"name": "Eredivisie", "country": "Netherlands", "type": "league", "tier": 2},
+    "Primeira_Liga": {"name": "Primeira Liga", "country": "Portugal", "type": "league", "tier": 2},
+    "Super_Lig": {"name": "Super Lig", "country": "Turkey", "type": "league", "tier": 2},
+    "Championship": {"name": "Championship", "country": "England", "type": "league", "tier": 2},
+    "Scottish_Premiership": {"name": "Scottish Premiership", "country": "Scotland", "type": "league", "tier": 2},
+    "Belgian_First_Division": {"name": "Belgian First Division", "country": "Belgium", "type": "league", "tier": 2},
+    "Swiss_Super_League": {"name": "Swiss Super League", "country": "Switzerland", "type": "league", "tier": 3},
+    "Austrian_Bundesliga": {"name": "Austrian Bundesliga", "country": "Austria", "type": "league", "tier": 3},
+    "Danish_Superliga": {"name": "Danish Superliga", "country": "Denmark", "type": "league", "tier": 3},
+    "Greek_Super_League": {"name": "Greek Super League", "country": "Greece", "type": "league", "tier": 3},
+    "Croatian_HNL": {"name": "Croatian HNL", "country": "Croatia", "type": "league", "tier": 3},
+    "Czech_Liga": {"name": "Czech Liga", "country": "Czech Republic", "type": "league", "tier": 3},
+    "Romanian_Liga_I": {"name": "Romanian Liga I", "country": "Romania", "type": "league", "tier": 3},
+    "Serbian_Super_Liga": {"name": "Serbian Super Liga", "country": "Serbia", "type": "league", "tier": 3},
+    "Slovak_Liga": {"name": "Slovak Liga", "country": "Slovakia", "type": "league", "tier": 3},
+    "Slovenian_Liga": {"name": "Slovenian Liga", "country": "Slovenia", "type": "league", "tier": 3},
+    "NB_I": {"name": "NB I", "country": "Hungary", "type": "league", "tier": 3},
+    "Ekstraklasa": {"name": "Ekstraklasa", "country": "Poland", "type": "league", "tier": 3},
+    "Ukrainian_Premier_League": {"name": "Ukrainian Premier League", "country": "Ukraine", "type": "league", "tier": 3},
+    "Ligat_Haal": {"name": "Ligat Ha'al", "country": "Israel", "type": "league", "tier": 3},
+    "Cyprus_First": {"name": "Cyprus First Division", "country": "Cyprus", "type": "league", "tier": 4},
+    "Gibraltar_Premier": {"name": "Gibraltar Premier", "country": "Gibraltar", "type": "league", "tier": 4},
+    "Kosovo_Superliga": {"name": "Kosovo Superliga", "country": "Kosovo", "type": "league", "tier": 4},
+    "Macedonian_First": {"name": "Macedonian First League", "country": "North Macedonia", "type": "league", "tier": 4},
+    "Maltese_Premier": {"name": "Maltese Premier", "country": "Malta", "type": "league", "tier": 4},
+    "Armenian_Premier": {"name": "Armenian Premier", "country": "Armenia", "type": "league", "tier": 4},
+    "Azerbaijan_Premier": {"name": "Azerbaijan Premier", "country": "Azerbaijan", "type": "league", "tier": 4},
+    "Bosnian_Premier": {"name": "Bosnian Premier", "country": "Bosnia", "type": "league", "tier": 4},
+    "Bulgarian_First_League": {"name": "Bulgarian First League", "country": "Bulgaria", "type": "league", "tier": 4},
+    "Kazakhstan_Premier": {"name": "Kazakhstan Premier", "country": "Kazakhstan", "type": "league", "tier": 4},
+    "Irish_Premier": {"name": "Irish Premier Division", "country": "Ireland", "type": "league", "tier": 4},
+    "Icelandic_Premier": {"name": "Icelandic Premier", "country": "Iceland", "type": "league", "tier": 4},
+
+    # English lower divisions
+    "League_One": {"name": "League One", "country": "England", "type": "league", "tier": 3},
+    "League_Two": {"name": "League Two", "country": "England", "type": "league", "tier": 4},
+
+    # Nordic leagues
+    "Allsvenskan": {"name": "Allsvenskan", "country": "Sweden", "type": "league", "tier": 3},
+    "Eliteserien": {"name": "Eliteserien", "country": "Norway", "type": "league", "tier": 3},
+    "Veikkausliiga": {"name": "Veikkausliiga", "country": "Finland", "type": "league", "tier": 3},
+
+    # African leagues
+    "Botola_Pro": {"name": "Botola Pro", "country": "Morocco", "type": "league", "tier": 4},
+    "Tunisian_Ligue_1": {"name": "Tunisian Ligue 1", "country": "Tunisia", "type": "league", "tier": 4},
+
+    # Oceania / Americas / Middle East
+    "A_League": {"name": "A-League Men", "country": "Australia", "type": "league", "tier": 3},
+    "Brazilian_Serie_A": {"name": "Brazilian Serie A", "country": "Brazil", "type": "league", "tier": 2},
+    "UAE_Pro_League": {"name": "UAE Pro League", "country": "UAE", "type": "league", "tier": 4},
+    "NZ_National_League": {"name": "NZ National League", "country": "New Zealand", "type": "league", "tier": 4},
+
+    # Women's leagues
+    "WSL": {"name": "Women's Super League", "country": "England", "type": "league", "tier": 5},
+
+    # UEFA Club Competitions
+    "UCL": {"name": "UEFA Champions League", "country": "Europe", "type": "cup", "tier": 1},
+    "UEL": {"name": "UEFA Europa League", "country": "Europe", "type": "cup", "tier": 2},
+    "Conference_League": {"name": "UEFA Conference League", "country": "Europe", "type": "cup", "tier": 3},
+    "UEFA_Super_Cup": {"name": "UEFA Super Cup", "country": "Europe", "type": "cup", "tier": 4},
+    "Club_World_Cup": {"name": "FIFA Club World Cup", "country": "International", "type": "cup", "tier": 3},
+    "FIFA_Intercontinental_Cup": {"name": "FIFA Intercontinental Cup", "country": "International", "type": "cup", "tier": 3},
+
+    # African Club Competitions
+    "CAF_CL": {"name": "CAF Champions League", "country": "Africa", "type": "cup", "tier": 3},
+    "CAF_Confederation_Cup": {"name": "CAF Confederation Cup", "country": "Africa", "type": "cup", "tier": 4},
+
+    # Other club cups
+    "OFC_Champions_League": {"name": "OFC Champions League", "country": "Oceania", "type": "cup", "tier": 4},
+    "Gulf_Champions_League": {"name": "Gulf Champions League", "country": "Middle East", "type": "cup", "tier": 4},
+
+    # Domestic cups
+    "FA_Cup": {"name": "FA Cup", "country": "England", "type": "domestic_cup", "tier": 2},
+    "League_Cup": {"name": "League Cup", "country": "England", "type": "domestic_cup", "tier": 3},
+    "DFB_Pokal": {"name": "DFB-Pokal", "country": "Germany", "type": "domestic_cup", "tier": 2},
+    "Copa_del_Rey": {"name": "Copa del Rey", "country": "Spain", "type": "domestic_cup", "tier": 2},
+    "Coppa_Italia": {"name": "Coppa Italia", "country": "Italy", "type": "domestic_cup", "tier": 2},
+    "Coupe_de_France": {"name": "Coupe de France", "country": "France", "type": "domestic_cup", "tier": 2},
+    "Taca_de_Portugal": {"name": "Taca de Portugal", "country": "Portugal", "type": "domestic_cup", "tier": 3},
+    "Taca_da_Liga": {"name": "Taca da Liga", "country": "Portugal", "type": "domestic_cup", "tier": 4},
+    "KNVB_Beker": {"name": "KNVB Beker", "country": "Netherlands", "type": "domestic_cup", "tier": 3},
+    "Scottish_Cup": {"name": "Scottish Cup", "country": "Scotland", "type": "domestic_cup", "tier": 3},
+    "Scottish_League_Cup": {"name": "Scottish League Cup", "country": "Scotland", "type": "domestic_cup", "tier": 4},
+    "Turkish_Cup": {"name": "Turkish Cup", "country": "Turkey", "type": "domestic_cup", "tier": 3},
+    "Austrian_Cup": {"name": "Austrian Cup", "country": "Austria", "type": "domestic_cup", "tier": 4},
+    "Belgian_Cup": {"name": "Belgian Cup", "country": "Belgium", "type": "domestic_cup", "tier": 3},
+    "Bulgarian_Cup": {"name": "Bulgarian Cup", "country": "Bulgaria", "type": "domestic_cup", "tier": 4},
+    "Croatian_Cup": {"name": "Croatian Cup", "country": "Croatia", "type": "domestic_cup", "tier": 4},
+    "Czech_Cup": {"name": "Czech Cup", "country": "Czech Republic", "type": "domestic_cup", "tier": 4},
+    "Cupa_Romaniei": {"name": "Cupa Romaniei", "country": "Romania", "type": "domestic_cup", "tier": 4},
+    "DBU_Pokalen": {"name": "DBU Pokalen", "country": "Denmark", "type": "domestic_cup", "tier": 4},
+    "Greek_Cup": {"name": "Greek Cup", "country": "Greece", "type": "domestic_cup", "tier": 4},
+    "Israeli_Cup": {"name": "Israeli Cup", "country": "Israel", "type": "domestic_cup", "tier": 4},
+    "Magyar_Kupa": {"name": "Magyar Kupa", "country": "Hungary", "type": "domestic_cup", "tier": 4},
+    "Moroccan_Cup": {"name": "Moroccan Cup", "country": "Morocco", "type": "domestic_cup", "tier": 4},
+    "NZ_Chatham_Cup": {"name": "NZ Chatham Cup", "country": "New Zealand", "type": "domestic_cup", "tier": 4},
+    "Polish_Cup": {"name": "Polish Cup", "country": "Poland", "type": "domestic_cup", "tier": 4},
+    "Schweizer_Pokal": {"name": "Schweizer Pokal", "country": "Switzerland", "type": "domestic_cup", "tier": 4},
+    "Serbian_Cup": {"name": "Serbian Cup", "country": "Serbia", "type": "domestic_cup", "tier": 4},
+    "Slovak_Cup": {"name": "Slovak Cup", "country": "Slovakia", "type": "domestic_cup", "tier": 4},
+    "Slovenian_Cup": {"name": "Slovenian Cup", "country": "Slovenia", "type": "domestic_cup", "tier": 4},
+    "Suomen_Cup": {"name": "Suomen Cup", "country": "Finland", "type": "domestic_cup", "tier": 4},
+    "Svenska_Cupen": {"name": "Svenska Cupen", "country": "Sweden", "type": "domestic_cup", "tier": 4},
+    "Tunisian_Cup": {"name": "Tunisian Cup", "country": "Tunisia", "type": "domestic_cup", "tier": 4},
+    "Tunisian_Super_Cup": {"name": "Tunisian Super Cup", "country": "Tunisia", "type": "domestic_cup", "tier": 4},
+    "Ukrainian_Cup": {"name": "Ukrainian Cup", "country": "Ukraine", "type": "domestic_cup", "tier": 4},
+    "Azerbaijan_Cup": {"name": "Azerbaijan Cup", "country": "Azerbaijan", "type": "domestic_cup", "tier": 4},
+    "UAE_League_Cup": {"name": "UAE League Cup", "country": "UAE", "type": "domestic_cup", "tier": 4},
+    "UAE_Presidents_Cup": {"name": "UAE President's Cup", "country": "UAE", "type": "domestic_cup", "tier": 4},
+
+    # Super cups / shields
+    "Supercopa": {"name": "Supercopa de Espana", "country": "Spain", "type": "domestic_cup", "tier": 4},
+    "Trophee_Champions": {"name": "Trophee des Champions", "country": "France", "type": "domestic_cup", "tier": 4},
+
+    # International Competitions
+    "World_Cup": {"name": "FIFA World Cup", "country": "International", "type": "international", "tier": 1},
+    "UEFA_Euros": {"name": "UEFA European Championship", "country": "Europe", "type": "international", "tier": 1},
+    "Copa_America": {"name": "Copa America", "country": "South America", "type": "international", "tier": 2},
+    "AFCON": {"name": "Africa Cup of Nations", "country": "Africa", "type": "international", "tier": 2},
+    "CONCACAF_Gold_Cup": {"name": "CONCACAF Gold Cup", "country": "North America", "type": "international", "tier": 2},
+    "UEFA_Nations_League": {"name": "UEFA Nations League", "country": "Europe", "type": "international", "tier": 3},
+    "UEFA_Euro_Qualifiers": {"name": "UEFA Euro Qualifiers", "country": "Europe", "type": "international", "tier": 3},
+    "UEFA_WC_Qualifiers": {"name": "UEFA World Cup Qualifiers", "country": "Europe", "type": "international", "tier": 3},
+}
+
+# Panna league code → Opta competition code (mirrors OPTA_LEAGUES in R)
+PANNA_ALIASES = {
+    "ENG": "EPL",
+    "ESP": "La_Liga",
+    "GER": "Bundesliga",
+    "ITA": "Serie_A",
+    "FRA": "Ligue_1",
+    "NED": "Eredivisie",
+    "POR": "Primeira_Liga",
+    "TUR": "Super_Lig",
+    "ENG2": "Championship",
+    "SCO": "Scottish_Premiership",
+}
+
+
+def get_competition_metadata(code):
+    """Get metadata for a competition code, with fallback to humanized name."""
+    if code in COMPETITION_METADATA:
+        return COMPETITION_METADATA[code]
+    return {
+        "name": code.replace("_", " "),
+        "country": "Unknown",
+        "type": "unknown",
+        "tier": 99,
+    }

--- a/scripts/opta/consolidate_opta.py
+++ b/scripts/opta/consolidate_opta.py
@@ -135,7 +135,7 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
 
     # Find all table types (subdirectories of opta/)
     # Exclude match_events (consolidated separately by league), events_consolidated (output dir), and models
-    exclude = {'match_events', 'events_consolidated', 'models'}
+    exclude = {'match_events', 'events_consolidated', 'models', 'xmetrics'}
     table_types = [d.name for d in opta_path.iterdir() if d.is_dir() and d.name not in exclude]
     print(f"Found table types: {table_types}")
 
@@ -162,7 +162,10 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
                 print(f"  Loaded {existing_count:,} existing rows from {existing_path}")
             except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError,
                     pyarrow.lib.ArrowInvalid) as e:
-                print(f"  Warning: Error reading existing {existing_path}: {e}")
+                print(f"  ERROR: Failed to read existing {existing_path}: {e}")
+                print(f"  Skipping {table_type} to prevent data loss")
+                errors += 1
+                continue
 
         # Read new hierarchical data, adding competition and season columns
         for f in parquet_files:
@@ -317,6 +320,10 @@ def generate_catalog(opta_dir="opta", manifest_path="opta-manifest.parquet",
             "data_types": sorted(info["data_types"]),
         }
 
+    if not competitions:
+        print("Catalog: ERROR - no competitions found, skipping catalog write")
+        return 1
+
     catalog = {
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "competitions": competitions,
@@ -325,11 +332,16 @@ def generate_catalog(opta_dir="opta", manifest_path="opta-manifest.parquet",
 
     output = Path(output_path)
     output.parent.mkdir(parents=True, exist_ok=True)
-    with open(output, "w") as f:
-        json.dump(catalog, f, indent=2)
+    try:
+        with open(output, "w") as f:
+            json.dump(catalog, f, indent=2)
+        size_kb = output.stat().st_size / 1024
+        print(f"Catalog: wrote {output} ({len(competitions)} competitions, {size_kb:.1f} KB)")
+    except OSError as e:
+        print(f"Catalog: ERROR writing {output}: {e}")
+        return 1
 
-    size_kb = output.stat().st_size / 1024
-    print(f"Catalog: wrote {output} ({len(competitions)} competitions, {size_kb:.1f} KB)")
+    return 0
 
 
 if __name__ == "__main__":
@@ -341,8 +353,13 @@ if __name__ == "__main__":
     errors = consolidate_opta()
     errors += consolidate_events_by_league()
 
-    # Generate data catalog
-    generate_catalog()
+    # Generate data catalog (non-fatal)
+    try:
+        catalog_errors = generate_catalog()
+        if catalog_errors:
+            logger.warning("Catalog generation had errors")
+    except Exception as e:
+        logger.warning("Catalog generation failed: %s", e)
 
     if errors:
         logger.error("%d error(s) occurred during consolidation", errors)

--- a/scripts/opta/consolidate_opta.py
+++ b/scripts/opta/consolidate_opta.py
@@ -7,11 +7,16 @@ Writes to:  opta/opta_{table_type}.parquet
            opta/events_consolidated/events_{league}.parquet (per-league events)
 """
 
+import json
 import logging
 import shutil
 import sys
+from datetime import datetime, timezone
+
 import pandas as pd
 from pathlib import Path
+
+from competition_metadata import get_competition_metadata, PANNA_ALIASES
 
 logger = logging.getLogger(__name__)
 
@@ -218,6 +223,100 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
     return errors
 
 
+def generate_catalog(opta_dir="opta", manifest_path="opta-manifest.parquet",
+                     output_path="opta/opta-catalog.json"):
+    """Generate a JSON catalog of all available Opta competitions and data.
+
+    Combines manifest (per-match has_* flags) with filesystem scan of
+    consolidated parquets to build a comprehensive data catalog.
+    """
+    opta_path = Path(opta_dir)
+    manifest_file = Path(manifest_path)
+
+    # Data types we track
+    data_types = ["player_stats", "shots", "shot_events", "match_events", "lineups",
+                  "events", "fixtures"]
+
+    # 1. Build competition/season info from manifest
+    comp_data = {}
+    if manifest_file.exists():
+        try:
+            mf = pd.read_parquet(manifest_file)
+            for (comp, season), group in mf.groupby(["competition", "season"]):
+                if comp not in comp_data:
+                    comp_data[comp] = {"seasons": set(), "n_matches": 0, "data_types": set()}
+                comp_data[comp]["seasons"].add(season)
+                comp_data[comp]["n_matches"] += len(group)
+                # Check has_* flags
+                for dt in ["player_stats", "shots", "match_events", "lineups"]:
+                    col = f"has_{dt}"
+                    if col in group.columns and group[col].any():
+                        comp_data[comp]["data_types"].add(dt)
+            print(f"Catalog: loaded {len(mf):,} manifest entries across {len(comp_data)} competitions")
+        except Exception as e:
+            print(f"Catalog: warning reading manifest: {e}")
+
+    # 2. Also scan consolidated parquets for competition/season columns
+    for dt in data_types:
+        consolidated_file = opta_path / f"opta_{dt}.parquet"
+        if not consolidated_file.exists():
+            continue
+        try:
+            df = pd.read_parquet(consolidated_file, columns=["competition", "season"])
+            for comp in df["competition"].unique():
+                if comp not in comp_data:
+                    comp_data[comp] = {"seasons": set(), "n_matches": 0, "data_types": set()}
+                comp_data[comp]["data_types"].add(dt)
+                comp_data[comp]["seasons"].update(
+                    df.loc[df["competition"] == comp, "season"].unique()
+                )
+        except Exception as e:
+            print(f"Catalog: warning scanning {consolidated_file}: {e}")
+
+    # Also scan events_consolidated/ for per-league event files
+    events_dir = opta_path / "events_consolidated"
+    if events_dir.exists():
+        for f in events_dir.glob("events_*.parquet"):
+            comp = f.stem.replace("events_", "")
+            if comp not in comp_data:
+                comp_data[comp] = {"seasons": set(), "n_matches": 0, "data_types": set()}
+            comp_data[comp]["data_types"].add("match_events")
+            try:
+                df = pd.read_parquet(f, columns=["season"])
+                comp_data[comp]["seasons"].update(df["season"].unique())
+            except Exception:
+                pass
+
+    # 3. Build catalog JSON
+    competitions = {}
+    for code in sorted(comp_data.keys()):
+        meta = get_competition_metadata(code)
+        info = comp_data[code]
+        competitions[code] = {
+            "name": meta["name"],
+            "country": meta["country"],
+            "type": meta["type"],
+            "tier": meta["tier"],
+            "seasons": sorted(info["seasons"], reverse=True),
+            "n_matches": info["n_matches"],
+            "data_types": sorted(info["data_types"]),
+        }
+
+    catalog = {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "competitions": competitions,
+        "panna_aliases": PANNA_ALIASES,
+    }
+
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with open(output, "w") as f:
+        json.dump(catalog, f, indent=2)
+
+    size_kb = output.stat().st_size / 1024
+    print(f"Catalog: wrote {output} ({len(competitions)} competitions, {size_kb:.1f} KB)")
+
+
 if __name__ == "__main__":
     logging.basicConfig(
         level=logging.INFO,
@@ -226,6 +325,10 @@ if __name__ == "__main__":
     )
     errors = consolidate_opta()
     errors += consolidate_events_by_league()
+
+    # Generate data catalog
+    generate_catalog()
+
     if errors:
         logger.error("%d error(s) occurred during consolidation", errors)
         sys.exit(1)

--- a/scripts/opta/consolidate_opta.py
+++ b/scripts/opta/consolidate_opta.py
@@ -14,6 +14,7 @@ import sys
 from datetime import datetime, timezone
 
 import pandas as pd
+import pyarrow.lib
 from pathlib import Path
 
 from competition_metadata import get_competition_metadata, PANNA_ALIASES
@@ -55,7 +56,8 @@ def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
                 existing_count = len(existing_df)
                 dfs.append(existing_df)
                 print(f"  {league}: Loaded {existing_count:,} existing rows")
-            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
+            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError,
+                    pyarrow.lib.ArrowInvalid) as e:
                 print(f"  ERROR: Failed to read existing {existing_file}: {e}")
                 print(f"  Skipping {league} to prevent data loss")
                 errors += 1
@@ -70,8 +72,10 @@ def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
                 df['competition'] = league
                 df['season'] = f.stem
                 dfs.append(df)
-            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
-                print(f"  Warning: Error reading {f}: {e}")
+            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError,
+                    pyarrow.lib.ArrowInvalid) as e:
+                print(f"  ERROR: Failed to read {f}: {e}")
+                errors += 1
 
         if not dfs:
             continue
@@ -97,7 +101,13 @@ def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
         # Backup existing file before overwriting
         if output_file.exists():
             backup_file = output_file.with_suffix('.parquet.backup')
-            shutil.copy2(output_file, backup_file)
+            try:
+                shutil.copy2(output_file, backup_file)
+            except OSError as e:
+                print(f"  ERROR: Failed to create backup for {output_file}: {e}")
+                print(f"  Skipping {league} to prevent data loss (cannot backup)")
+                errors += 1
+                continue
         combined.to_parquet(output_file, index=False, compression='gzip')
 
         size_mb = output_file.stat().st_size / (1024 * 1024)
@@ -112,15 +122,12 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
 
     Merges existing consolidated files with newly scraped hierarchical files,
     deduplicating by appropriate keys. In GHA, existing consolidated files are
-    downloaded to the parent directory (e.g., data/opta_player_stats.parquet)
+    downloaded to the opta directory (e.g., opta/opta_player_stats.parquet)
     before consolidation runs.
     """
     opta_path = Path(opta_dir)
     output_path = Path(output_dir)
     output_path.mkdir(exist_ok=True)
-
-    # Parent directory where GHA downloads existing consolidated files
-    parent_dir = opta_path.parent
 
     if not opta_path.exists():
         print(f"Opta directory not found: {opta_dir}")
@@ -144,23 +151,18 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
         print(f"Consolidating opta_{table_type}... Found {len(parquet_files)} files")
 
         # Read existing consolidated file first (contains historical data)
-        # Check both parent dir (where GHA downloads) and output dir (from previous run)
         dfs = []
         existing_count = 0
-        for existing_path in [
-            parent_dir / f"opta_{table_type}.parquet",
-            output_path / f"opta_{table_type}.parquet",
-        ]:
-            if existing_path.exists():
-                try:
-                    existing_df = pd.read_parquet(existing_path)
-                    existing_count = len(existing_df)
-                    dfs.append(existing_df)
-                    print(f"  Loaded {existing_count:,} existing rows from {existing_path}")
-                    break  # Successfully loaded - don't try other sources
-                except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
-                    print(f"  Warning: Error reading existing {existing_path}: {e}")
-                    # Fall through to try the next path
+        existing_path = output_path / f"opta_{table_type}.parquet"
+        if existing_path.exists():
+            try:
+                existing_df = pd.read_parquet(existing_path)
+                existing_count = len(existing_df)
+                dfs.append(existing_df)
+                print(f"  Loaded {existing_count:,} existing rows from {existing_path}")
+            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError,
+                    pyarrow.lib.ArrowInvalid) as e:
+                print(f"  Warning: Error reading existing {existing_path}: {e}")
 
         # Read new hierarchical data, adding competition and season columns
         for f in parquet_files:
@@ -173,8 +175,10 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
                 df['competition'] = competition
                 df['season'] = season
                 dfs.append(df)
-            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
-                print(f"  Warning: Error reading {f}: {e}")
+            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError,
+                    pyarrow.lib.ArrowInvalid) as e:
+                print(f"  ERROR: Failed to read {f}: {e}")
+                errors += 1
 
         if not dfs:
             print(f"  Skipping {table_type} - no valid data")
@@ -212,7 +216,13 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
         output_file = output_path / f"opta_{table_type}.parquet"
         if output_file.exists():
             backup_file = output_file.with_suffix('.parquet.backup')
-            shutil.copy2(output_file, backup_file)
+            try:
+                shutil.copy2(output_file, backup_file)
+            except OSError as e:
+                print(f"  ERROR: Failed to create backup for {output_file}: {e}")
+                print(f"  Skipping {table_type} to prevent data loss (cannot backup)")
+                errors += 1
+                continue
         combined.to_parquet(output_file, index=False)
 
         size_mb = output_file.stat().st_size / (1024 * 1024)
@@ -227,8 +237,10 @@ def generate_catalog(opta_dir="opta", manifest_path="opta-manifest.parquet",
                      output_path="opta/opta-catalog.json"):
     """Generate a JSON catalog of all available Opta competitions and data.
 
-    Combines manifest (per-match has_* flags) with filesystem scan of
-    consolidated parquets to build a comprehensive data catalog.
+    Combines three data sources to build a comprehensive catalog:
+    1. Manifest (per-match has_* flags for match counts)
+    2. Consolidated parquets (competition/season columns per data type)
+    3. Per-league event files in events_consolidated/
     """
     opta_path = Path(opta_dir)
     manifest_file = Path(manifest_path)
@@ -253,7 +265,8 @@ def generate_catalog(opta_dir="opta", manifest_path="opta-manifest.parquet",
                     if col in group.columns and group[col].any():
                         comp_data[comp]["data_types"].add(dt)
             print(f"Catalog: loaded {len(mf):,} manifest entries across {len(comp_data)} competitions")
-        except Exception as e:
+        except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError,
+                pyarrow.lib.ArrowInvalid, KeyError) as e:
             print(f"Catalog: warning reading manifest: {e}")
 
     # 2. Also scan consolidated parquets for competition/season columns
@@ -270,7 +283,8 @@ def generate_catalog(opta_dir="opta", manifest_path="opta-manifest.parquet",
                 comp_data[comp]["seasons"].update(
                     df.loc[df["competition"] == comp, "season"].unique()
                 )
-        except Exception as e:
+        except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError,
+                pyarrow.lib.ArrowInvalid, KeyError) as e:
             print(f"Catalog: warning scanning {consolidated_file}: {e}")
 
     # Also scan events_consolidated/ for per-league event files
@@ -284,8 +298,9 @@ def generate_catalog(opta_dir="opta", manifest_path="opta-manifest.parquet",
             try:
                 df = pd.read_parquet(f, columns=["season"])
                 comp_data[comp]["seasons"].update(df["season"].unique())
-            except Exception:
-                pass
+            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError,
+                    pyarrow.lib.ArrowInvalid, KeyError) as e:
+                print(f"Catalog: warning scanning {f}: {e}")
 
     # 3. Build catalog JSON
     competitions = {}

--- a/scripts/opta/consolidate_opta.py
+++ b/scripts/opta/consolidate_opta.py
@@ -7,9 +7,13 @@ Writes to:  opta/opta_{table_type}.parquet
            opta/events_consolidated/events_{league}.parquet (per-league events)
 """
 
+import logging
+import shutil
 import sys
 import pandas as pd
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
@@ -46,7 +50,7 @@ def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
                 existing_count = len(existing_df)
                 dfs.append(existing_df)
                 print(f"  {league}: Loaded {existing_count:,} existing rows")
-            except Exception as e:
+            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
                 print(f"  ERROR: Failed to read existing {existing_file}: {e}")
                 print(f"  Skipping {league} to prevent data loss")
                 errors += 1
@@ -61,7 +65,7 @@ def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
                 df['competition'] = league
                 df['season'] = f.stem
                 dfs.append(df)
-            except Exception as e:
+            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
                 print(f"  Warning: Error reading {f}: {e}")
 
         if not dfs:
@@ -76,14 +80,19 @@ def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
             if len(combined) < before:
                 print(f"  {league}: Removed {before - len(combined):,} duplicates")
 
-        # Sanity check: don't write dramatically fewer rows than existed
-        if existing_count > 0 and len(combined) < existing_count * 0.5:
+        # Sanity check: don't write if row count drops more than 10%
+        if existing_count > 0 and len(combined) < existing_count * 0.9:
+            pct_loss = 100 * (1 - len(combined) / existing_count)
             print(f"  ERROR: {league} row count dropped from {existing_count:,} to "
-                  f"{len(combined):,}. Skipping write to prevent data loss.")
+                  f"{len(combined):,} ({pct_loss:.1f}% loss). Skipping write to prevent data loss.")
             errors += 1
             continue
 
         output_file = output_path / f"events_{league}.parquet"
+        # Backup existing file before overwriting
+        if output_file.exists():
+            backup_file = output_file.with_suffix('.parquet.backup')
+            shutil.copy2(output_file, backup_file)
         combined.to_parquet(output_file, index=False, compression='gzip')
 
         size_mb = output_file.stat().st_size / (1024 * 1024)
@@ -144,7 +153,7 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
                     dfs.append(existing_df)
                     print(f"  Loaded {existing_count:,} existing rows from {existing_path}")
                     break  # Successfully loaded - don't try other sources
-                except Exception as e:
+                except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
                     print(f"  Warning: Error reading existing {existing_path}: {e}")
                     # Fall through to try the next path
 
@@ -159,7 +168,7 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
                 df['competition'] = competition
                 df['season'] = season
                 dfs.append(df)
-            except Exception as e:
+            except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
                 print(f"  Warning: Error reading {f}: {e}")
 
         if not dfs:
@@ -186,15 +195,19 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
             if len(combined) < before_count:
                 print(f"  Removed {before_count - len(combined):,} duplicate rows")
 
-        # Sanity check: don't write dramatically fewer rows than existed
-        if existing_count > 0 and len(combined) < existing_count * 0.5:
+        # Sanity check: don't write if row count drops more than 10%
+        if existing_count > 0 and len(combined) < existing_count * 0.9:
+            pct_loss = 100 * (1 - len(combined) / existing_count)
             print(f"  ERROR: {table_type} row count dropped from {existing_count:,} to "
-                  f"{len(combined):,}. Skipping write to prevent data loss.")
+                  f"{len(combined):,} ({pct_loss:.1f}% loss). Skipping write to prevent data loss.")
             errors += 1
             continue
 
-        # Write consolidated parquet
+        # Write consolidated parquet (backup existing first)
         output_file = output_path / f"opta_{table_type}.parquet"
+        if output_file.exists():
+            backup_file = output_file.with_suffix('.parquet.backup')
+            shutil.copy2(output_file, backup_file)
         combined.to_parquet(output_file, index=False)
 
         size_mb = output_file.stat().st_size / (1024 * 1024)
@@ -206,8 +219,13 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(levelname)s] %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
     errors = consolidate_opta()
     errors += consolidate_events_by_league()
     if errors:
-        print(f"\n{errors} error(s) occurred during consolidation")
+        logger.error("%d error(s) occurred during consolidation", errors)
         sys.exit(1)

--- a/scripts/opta/opta_scraper.py
+++ b/scripts/opta/opta_scraper.py
@@ -529,11 +529,16 @@ class OptaScraper:
 
                 # Rate limited or server error - retry with backoff
                 if resp.status_code == 429 or resp.status_code >= 500:
-                    wait = 2 ** attempt + random.uniform(0, 1)
-                    print(f"HTTP {resp.status_code} for {endpoint} "
-                          f"(attempt {attempt}/{max_retries}), retrying in {wait:.1f}s...")
-                    time.sleep(wait)
-                    continue
+                    if attempt < max_retries:
+                        wait = 2 ** attempt + random.uniform(0, 1)
+                        print(f"HTTP {resp.status_code} for {endpoint} "
+                              f"(attempt {attempt}/{max_retries}), retrying in {wait:.1f}s...")
+                        time.sleep(wait)
+                        continue
+                    else:
+                        print(f"Request failed for {endpoint}: HTTP {resp.status_code} "
+                              f"after {max_retries} attempts")
+                        return None
 
                 resp.raise_for_status()
                 return resp.json()

--- a/scripts/opta/opta_scraper.py
+++ b/scripts/opta/opta_scraper.py
@@ -15,8 +15,11 @@ API Endpoints:
 Data extracted:
 - player_stats: 263+ columns per player-match
 - events: Goal/card/sub timing for splint boundaries
-- shots: Individual shots with x/y coords for xG modeling
+- shots: Aggregated shot counts per player-match (by type, location, body part)
+- shot_events: Individual shots with x/y coords for xG modeling
+- match_events: All events with x/y coords (passes, tackles, aerials, etc.)
 - lineups: Starting XI with positions and minutes played
+- fixtures: Match fixtures with scores and statuses
 """
 
 import requests
@@ -83,7 +86,7 @@ class ShotEvent:
     y: float
     outcome: int  # 1=on target, 0=off target
     is_goal: bool
-    type_id: int  # 13=attempt saved, 14=post, 15=miss, 16=goal
+    type_id: int  # 13=miss, 14=post, 15=attempt saved, 16=goal
     # Qualifiers (extracted from qualifier list)
     body_part: str = ""  # Head, RightFoot, LeftFoot
     situation: str = ""  # OpenPlay, SetPiece, Corner, Penalty, etc.
@@ -509,8 +512,8 @@ class OptaScraper:
                max_retries: int = 3) -> Optional[Dict]:
         """Fetch from API with JSON format and exponential backoff retry.
 
-        Retries on transient failures (429, 500-504, connection errors).
-        Returns None on permanent failures (400, 404, etc.).
+        Retries on transient failures (429, 5xx, connection/JSON errors).
+        Returns None on permanent failures (400, 403, 404).
         """
         url = f"{self.BASE_URL}/{endpoint}"
         default_params = {"_rt": "c", "_fmt": "json"}
@@ -556,8 +559,14 @@ class OptaScraper:
                 print(f"Request failed for {endpoint}: {e}")
                 return None
             except json.JSONDecodeError as e:
-                print(f"JSON parse failed for {endpoint}: {e}")
-                return None
+                if attempt < max_retries:
+                    wait = 2 ** attempt + random.uniform(0, 1)
+                    print(f"JSON parse error for {endpoint} "
+                          f"(attempt {attempt}/{max_retries}): {e}, retrying in {wait:.1f}s...")
+                    time.sleep(wait)
+                else:
+                    print(f"JSON parse failed for {endpoint} after {max_retries} attempts: {e}")
+                    return None
 
         print(f"Request failed for {endpoint} after {max_retries} attempts")
         return None
@@ -852,7 +861,7 @@ class OptaScraper:
         shots = []
         match_id = event_data.get("matchInfo", {}).get("id", "")
 
-        # Shot type IDs in Opta: 13=attempt saved, 14=post, 15=miss, 16=goal
+        # Shot type IDs in Opta: 13=miss, 14=post, 15=attempt saved, 16=goal
         shot_type_ids = {13, 14, 15, 16}
 
         for event in event_data.get("liveData", {}).get("event", []):
@@ -864,7 +873,7 @@ class OptaScraper:
             qualifiers = {q.get("qualifierId"): q.get("value")
                          for q in event.get("qualifier", [])}
 
-            # Body part from qualifiers (15=Head, 72=LeftFoot, 72=RightFoot)
+            # Body part from qualifiers (15=Head, 72=LeftFoot; absent both -> RightFoot)
             body_part = ""
             if 15 in qualifiers:
                 body_part = "Head"

--- a/scripts/opta/opta_scraper.py
+++ b/scripts/opta/opta_scraper.py
@@ -505,23 +505,57 @@ class OptaScraper:
         if self._request_count % 10 == 0:
             self._set_random_headers()
 
-    def _fetch(self, endpoint: str, params: Dict[str, str]) -> Optional[Dict]:
-        """Fetch from API with JSON format"""
-        self._rate_limit()
+    def _fetch(self, endpoint: str, params: Dict[str, str],
+               max_retries: int = 3) -> Optional[Dict]:
+        """Fetch from API with JSON format and exponential backoff retry.
+
+        Retries on transient failures (429, 500-504, connection errors).
+        Returns None on permanent failures (400, 404, etc.).
+        """
         url = f"{self.BASE_URL}/{endpoint}"
         default_params = {"_rt": "c", "_fmt": "json"}
         all_params = {**default_params, **params}
 
-        try:
-            resp = self.session.get(url, params=all_params, timeout=30)
-            resp.raise_for_status()
-            return resp.json()
-        except requests.RequestException as e:
-            print(f"Request failed for {endpoint}: {e}")
-            return None
-        except json.JSONDecodeError as e:
-            print(f"JSON parse failed: {e}")
-            return None
+        for attempt in range(1, max_retries + 1):
+            self._rate_limit()
+            try:
+                resp = self.session.get(url, params=all_params, timeout=30)
+
+                # Permanent client errors - don't retry
+                if resp.status_code in (400, 403, 404):
+                    if resp.status_code != 404:
+                        print(f"Request failed for {endpoint}: HTTP {resp.status_code}")
+                    return None
+
+                # Rate limited or server error - retry with backoff
+                if resp.status_code == 429 or resp.status_code >= 500:
+                    wait = 2 ** attempt + random.uniform(0, 1)
+                    print(f"HTTP {resp.status_code} for {endpoint} "
+                          f"(attempt {attempt}/{max_retries}), retrying in {wait:.1f}s...")
+                    time.sleep(wait)
+                    continue
+
+                resp.raise_for_status()
+                return resp.json()
+
+            except (requests.ConnectionError, requests.Timeout) as e:
+                if attempt < max_retries:
+                    wait = 2 ** attempt + random.uniform(0, 1)
+                    print(f"Connection error for {endpoint} "
+                          f"(attempt {attempt}/{max_retries}): {e}, retrying in {wait:.1f}s...")
+                    time.sleep(wait)
+                else:
+                    print(f"Request failed for {endpoint} after {max_retries} attempts: {e}")
+                    return None
+            except requests.RequestException as e:
+                print(f"Request failed for {endpoint}: {e}")
+                return None
+            except json.JSONDecodeError as e:
+                print(f"JSON parse failed for {endpoint}: {e}")
+                return None
+
+        print(f"Request failed for {endpoint} after {max_retries} attempts")
+        return None
 
     def discover_seasons(self, competition: str) -> Dict[str, str]:
         """

--- a/scripts/opta/requirements.txt
+++ b/scripts/opta/requirements.txt
@@ -1,3 +1,3 @@
-requests>=2.28.0
-pandas>=2.0.0
-pyarrow>=14.0.0
+requests>=2.28.0,<3.0.0
+pandas>=2.0.0,<3.0.0
+pyarrow>=14.0.0,<19.0.0

--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -23,12 +23,16 @@ Usage:
 
 import json
 import argparse
+import logging
 import sys
 from pathlib import Path
 from datetime import datetime
 from opta_scraper import OptaScraper, MatchEvent, ShotEvent, PlayerLineup, AllMatchEvent
 from dataclasses import asdict
 import pandas as pd
+import requests
+
+logger = logging.getLogger(__name__)
 
 
 def load_manifest(manifest_path: Path, include_unavailable: bool = True) -> tuple:
@@ -60,7 +64,7 @@ def load_manifest(manifest_path: Path, include_unavailable: bool = True) -> tupl
 
         print(f"Loaded manifest: {len(complete_set):,} complete, {len(unavailable_set):,} unavailable")
         return complete_set, unavailable_set
-    except Exception as e:
+    except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
         print(f"Warning: Error loading manifest: {e}")
         return set(), set()
 
@@ -485,6 +489,11 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
 
 def main():
     """Scrape Big 5 leagues"""
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(levelname)s] %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
     sys.stdout.reconfigure(encoding='utf-8')
 
     # Load seasons config
@@ -586,8 +595,8 @@ def main():
             results.append(result)
             # Collect manifest records from this season
             all_new_manifest_records.extend(result.get("manifest_records", []))
-        except Exception as e:
-            print(f"ERROR scraping {league} {season_name}: {e}")
+        except (requests.RequestException, ValueError, KeyError, OSError) as e:
+            logger.error("Failed scraping %s %s: %s", league, season_name, e, exc_info=True)
             results.append({
                 "competition": league,
                 "season": season_name,

--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -24,12 +24,14 @@ Usage:
 import json
 import argparse
 import logging
+import shutil
 import sys
 from pathlib import Path
 from datetime import datetime
 from opta_scraper import OptaScraper, MatchEvent, ShotEvent, PlayerLineup, AllMatchEvent
 from dataclasses import asdict
 import pandas as pd
+import pyarrow.lib
 import requests
 
 logger = logging.getLogger(__name__)
@@ -64,7 +66,8 @@ def load_manifest(manifest_path: Path, include_unavailable: bool = True) -> tupl
 
         print(f"Loaded manifest: {len(complete_set):,} complete, {len(unavailable_set):,} unavailable")
         return complete_set, unavailable_set
-    except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError) as e:
+    except (pd.errors.ParserError, FileNotFoundError, OSError, ValueError,
+            pyarrow.lib.ArrowInvalid) as e:
         print(f"Warning: Error loading manifest: {e}")
         return set(), set()
 
@@ -80,13 +83,24 @@ def update_manifest(manifest_path: Path, new_matches: list):
     new_df = pd.DataFrame(new_matches)
 
     if manifest_path.exists():
-        existing_df = pd.read_parquet(manifest_path)
-        # Combine and deduplicate (keep new records for same match_id/competition/season)
-        combined = pd.concat([existing_df, new_df], ignore_index=True)
-        combined = combined.drop_duplicates(
-            subset=['match_id', 'competition', 'season'],
-            keep='last'
-        )
+        # Backup before modifying
+        backup_path = manifest_path.with_suffix('.parquet.backup')
+        try:
+            shutil.copy2(manifest_path, backup_path)
+        except OSError as e:
+            logger.warning("Could not backup manifest: %s", e)
+
+        try:
+            existing_df = pd.read_parquet(manifest_path)
+            # Combine and deduplicate (keep new records for same match_id/competition/season)
+            combined = pd.concat([existing_df, new_df], ignore_index=True)
+            combined = combined.drop_duplicates(
+                subset=['match_id', 'competition', 'season'],
+                keep='last'
+            )
+        except (pd.errors.ParserError, OSError, ValueError, pyarrow.lib.ArrowInvalid) as e:
+            logger.error("Failed to read existing manifest: %s. Writing new records only.", e)
+            combined = new_df
     else:
         combined = new_df
 
@@ -400,7 +414,11 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
     def combine_and_save(new_data, output_path, dedup_cols):
         if not new_data:
             if output_path.exists():
-                return pd.read_parquet(output_path)
+                try:
+                    return pd.read_parquet(output_path)
+                except (pd.errors.ParserError, OSError, ValueError, pyarrow.lib.ArrowInvalid) as e:
+                    logger.error("Failed to read existing %s: %s", output_path, e)
+                    return pd.DataFrame()
             return pd.DataFrame()
 
         if isinstance(new_data[0], pd.DataFrame):
@@ -409,9 +427,13 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
             new_df = pd.DataFrame(new_data)
 
         if output_path.exists():
-            existing_df = pd.read_parquet(output_path)
-            combined = pd.concat([existing_df, new_df], ignore_index=True)
-            combined = combined.drop_duplicates(subset=dedup_cols)
+            try:
+                existing_df = pd.read_parquet(output_path)
+                combined = pd.concat([existing_df, new_df], ignore_index=True)
+                combined = combined.drop_duplicates(subset=dedup_cols)
+            except (pd.errors.ParserError, OSError, ValueError, pyarrow.lib.ArrowInvalid) as e:
+                logger.error("Failed to read existing %s: %s. Writing new data only.", output_path, e)
+                combined = new_df
         else:
             combined = new_df
 
@@ -595,8 +617,15 @@ def main():
             results.append(result)
             # Collect manifest records from this season
             all_new_manifest_records.extend(result.get("manifest_records", []))
-        except (requests.RequestException, ValueError, KeyError, OSError) as e:
+        except (requests.RequestException, ValueError, OSError) as e:
             logger.error("Failed scraping %s %s: %s", league, season_name, e, exc_info=True)
+            results.append({
+                "competition": league,
+                "season": season_name,
+                "error": str(e)
+            })
+        except Exception as e:
+            logger.error("Unexpected error scraping %s %s: %s", league, season_name, e, exc_info=True)
             results.append({
                 "competition": league,
                 "season": season_name,
@@ -622,19 +651,23 @@ def main():
     print(f"Total player records: {total_players}")
     print(f"Total shot records: {total_shots}")
 
-    # Save results summary
+    # Save results summary (used by GHA to distinguish "no data" from "crash")
     summary_path = script_dir / "data" / "scrape_summary.json"
-    with open(summary_path, "w") as f:
-        json.dump({
-            "timestamp": datetime.now().isoformat(),
-            "results": results,
-            "totals": {
-                "new_matches": total_new,
-                "total_matches": total_matches,
-                "player_records": total_players,
-                "shot_records": total_shots,
-            }
-        }, f, indent=2)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(summary_path, "w") as f:
+            json.dump({
+                "timestamp": datetime.now().isoformat(),
+                "results": results,
+                "totals": {
+                    "new_matches": total_new,
+                    "total_matches": total_matches,
+                    "player_records": total_players,
+                    "shot_records": total_shots,
+                }
+            }, f, indent=2)
+    except OSError as e:
+        logger.error("Failed to write scrape summary: %s", e)
 
     print(f"\nSummary saved to {summary_path}")
 

--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -8,8 +8,11 @@ gigabytes of data to check for existing matches.
 Data is saved to pannadata/data/opta/ with structure:
 - pannadata/data/opta/player_stats/{league}/{season}.parquet
 - pannadata/data/opta/shots/{league}/{season}.parquet
+- pannadata/data/opta/shot_events/{league}/{season}.parquet
 - pannadata/data/opta/match_events/{league}/{season}.parquet
+- pannadata/data/opta/events/{league}/{season}.parquet
 - pannadata/data/opta/lineups/{league}/{season}.parquet
+- pannadata/data/opta/fixtures/{league}/{season}.parquet
 
 Usage:
     python scrape_opta.py                           # Scrape all leagues, current season
@@ -88,7 +91,8 @@ def update_manifest(manifest_path: Path, new_matches: list):
         try:
             shutil.copy2(manifest_path, backup_path)
         except OSError as e:
-            logger.warning("Could not backup manifest: %s", e)
+            logger.error("Could not backup manifest: %s. Skipping manifest update.", e)
+            return
 
         try:
             existing_df = pd.read_parquet(manifest_path)
@@ -99,8 +103,18 @@ def update_manifest(manifest_path: Path, new_matches: list):
                 keep='last'
             )
         except (pd.errors.ParserError, OSError, ValueError, pyarrow.lib.ArrowInvalid) as e:
-            logger.error("Failed to read existing manifest: %s. Writing new records only.", e)
-            combined = new_df
+            logger.error("Failed to read existing manifest: %s. Trying backup.", e)
+            try:
+                existing_df = pd.read_parquet(backup_path)
+                logger.info("Recovered manifest from backup")
+                combined = pd.concat([existing_df, new_df], ignore_index=True)
+                combined = combined.drop_duplicates(
+                    subset=['match_id', 'competition', 'season'],
+                    keep='last'
+                )
+            except Exception:
+                logger.error("Backup also unreadable. Writing new records only.")
+                combined = new_df
     else:
         combined = new_df
 
@@ -220,6 +234,8 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
         unavailable_matches: Set of (match_id, competition, season) tuples with 404 events
         force_rescrape: If True, ignore manifest and rescrape all matches
         retry_unavailable: If True, retry matches that previously had 404 for events
+        scrape_types: List of data types to scrape (e.g., ["fixtures"]).
+                      None or ["all"] scrapes all types.
 
     Returns:
         dict with scraping results and list of new match records for manifest
@@ -430,10 +446,10 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
             try:
                 existing_df = pd.read_parquet(output_path)
                 combined = pd.concat([existing_df, new_df], ignore_index=True)
-                combined = combined.drop_duplicates(subset=dedup_cols)
+                combined = combined.drop_duplicates(subset=dedup_cols, keep='last')
             except (pd.errors.ParserError, OSError, ValueError, pyarrow.lib.ArrowInvalid) as e:
-                logger.error("Failed to read existing %s: %s. Writing new data only.", output_path, e)
-                combined = new_df
+                logger.error("Failed to read existing %s: %s. Skipping write to prevent data loss.", output_path, e)
+                return new_df
         else:
             combined = new_df
 
@@ -510,7 +526,7 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
 
 
 def main():
-    """Scrape Big 5 leagues"""
+    """Main entry point for Opta data scraping."""
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s [%(levelname)s] %(message)s',
@@ -522,7 +538,7 @@ def main():
     seasons_config = load_seasons_config()
 
     # Parse command line args
-    parser = argparse.ArgumentParser(description="Scrape Big 5 European leagues from Opta")
+    parser = argparse.ArgumentParser(description="Scrape Opta league data")
     parser.add_argument("--leagues", nargs="+",
                        choices=list(seasons_config.keys()),
                        help="Specific leagues to scrape (default: all)")
@@ -651,6 +667,11 @@ def main():
     print(f"Total player records: {total_players}")
     print(f"Total shot records: {total_shots}")
 
+    # Check for failures
+    error_count = sum(1 for r in results if "error" in r)
+    if error_count > 0:
+        logger.error("%d of %d league-seasons had errors", error_count, len(scrape_plan))
+
     # Save results summary (used by GHA to distinguish "no data" from "crash")
     summary_path = script_dir / "data" / "scrape_summary.json"
     summary_path.parent.mkdir(parents=True, exist_ok=True)
@@ -666,10 +687,14 @@ def main():
                     "shot_records": total_shots,
                 }
             }, f, indent=2)
+        print(f"\nSummary saved to {summary_path}")
     except OSError as e:
         logger.error("Failed to write scrape summary: %s", e)
+        print(f"\nWARNING: Failed to save summary to {summary_path}")
 
-    print(f"\nSummary saved to {summary_path}")
+    # Exit non-zero if all league-seasons failed
+    if error_count > 0 and error_count == len(scrape_plan) and len(scrape_plan) > 0:
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Harden scraper & consolidation**: Exponential backoff retries, tighter data-loss thresholds (50% → 10%), `.parquet.backup` safety copies, specific exception handling, proper logging with timestamps, pinned dependency versions
- **Add Opta data catalog**: New `opta-catalog.json` generated during consolidation with competition metadata (name, country, type, tier), season lists, match counts, and data type availability across 105+ competitions. Uploaded to `opta-latest` GitHub release
- **Rewrite documentation**: README updated to reflect Opta as primary source with all 15 leagues, 7 data types, accurate directory structure, and consolidated file docs. Fixed scripts/README.md ordering

## Changed files

| File | Change |
|------|--------|
| `scripts/opta/opta_scraper.py` | Add retry with exponential backoff |
| `scripts/opta/consolidate_opta.py` | Tighter thresholds, backups, catalog generation, logging |
| `scripts/opta/competition_metadata.py` | New: competition code → metadata mapping |
| `scripts/opta/scrape_opta.py` | Logging, workflow exit code handling |
| `scripts/opta/requirements.txt` | Pin upper bounds |
| `.github/workflows/daily-opta-scrape.yml` | Upload catalog to release, crash vs no-data distinction |
| `README.md` | Full rewrite with Opta-first docs |
| `scripts/README.md` | Fix source ordering and layout |

## Test plan

- [ ] Verify `daily-opta-scrape.yml` workflow runs successfully
- [ ] Confirm `opta-catalog.json` appears in `opta-latest` release
- [ ] Check backup `.parquet.backup` files created during consolidation
- [ ] Validate retry logic handles transient API failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)