### PR TITLE
Merge dev: blog data pipeline, scraper hardening, and join fix

### DIFF
--- a/BLOG_DATA_SETUP.md
+++ b/BLOG_DATA_SETUP.md
@@ -57,7 +57,7 @@ Produced by `panna/data-raw/match-predictions-opta/10_export_blog_data.R` only (
 source("data-raw/match-predictions-opta/10_export_blog_data.R")
 ```
 
-Requires: `cache-opta/07_seasonal_ratings.rds` (from Opta RAPM pipeline), `gh` CLI authenticated.
+Requires: `cache-skills/06_seasonal_ratings.rds` (preferred, from Skills pipeline) or `cache-opta/07_seasonal_ratings.rds` (fallback, from Opta RAPM pipeline), `gh` CLI authenticated.
 
 ### Match Predictions
 

--- a/BLOG_DATA_SETUP.md
+++ b/BLOG_DATA_SETUP.md
@@ -17,7 +17,7 @@ Produced by either path. The GHA workflow uploads to Cloudflare R2; the panna pi
 |---|---|---|
 | `panna_rank` | integer | Overall rank (1 = best) |
 | `player_name` | string | Player name |
-| `panna` | double | Overall rating (offense - defense) |
+| `panna` | double | Overall xRAPM rating (positive = better) |
 | `offense` | double | Contribution to creating xG |
 | `defense` | double | Contribution to preventing xG (negative = good) |
 | `spm_overall` | double | SPM overall rating |

--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ shots <- load_shots()
 
 | Release Tag | Contents |
 |-------------|----------|
-| opta-latest | Consolidated Opta files (player_stats, shots, fixtures) |
+| opta-latest | Consolidated Opta files (player_stats, shots, shot_events, events, lineups, fixtures, manifest, catalog) + per-league events |
 | fbref-latest | FBref parquet archives |
 | understat-latest | Understat parquet archives |
 | epv-models | Pre-trained xG, xPass, EPV models |
+| ratings-data | Seasonal xRAPM + SPM parquets (from panna pipeline) |
 
 ## Syncing Data
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ shots <- load_shots()
 
 | Release Tag | Contents |
 |-------------|----------|
-| opta-latest | Consolidated Opta files (player_stats, shots, shot_events, events, lineups, fixtures, manifest, catalog) + per-league events |
+| opta-latest | Consolidated Opta parquets (player_stats, shots, shot_events, events, lineups, fixtures, match_stats, skills, xmetrics, manifest) + per-league events |
 | fbref-latest | FBref parquet archives |
 | understat-latest | Understat parquet archives |
 | epv-models | Pre-trained xG, xPass, EPV models |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,9 +52,11 @@ data/
 │   ├── player_stats/
 │   ├── events/
 │   ├── lineups/
-│   ├── opta_player_stats.parquet   # Consolidated
-│   ├── opta_shots.parquet          # Consolidated
-│   └── opta_fixtures.parquet       # Consolidated
+│   ├── opta_player_stats.parquet   # Consolidated (9 types total:
+│   ├── opta_shots.parquet          #   player_stats, shots, shot_events,
+│   ├── opta_fixtures.parquet       #   events, lineups, fixtures,
+│   ├── opta_match_stats.parquet    #   match_stats, skills, xmetrics)
+│   └── opta_*.parquet              # All uploaded to opta-latest release
 ├── understat/       # Understat data (parquet only)
 │   ├── roster/
 │   ├── shots/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -48,7 +48,7 @@ data/
 │   ├── passing/
 │   ├── defense/
 │   └── ...
-├── opta/            # Opta data (RDS + parquet)
+├── opta/            # Opta data (parquet per season + consolidated)
 │   ├── player_stats/
 │   ├── events/
 │   ├── lineups/

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -2,6 +2,9 @@ library(arrow)
 library(dplyr)
 
 # Player ratings - latest season xRAPM + SPM
+for (f in c("source/seasonal_xrapm.parquet", "source/seasonal_spm.parquet")) {
+  if (!file.exists(f)) stop("Required file not found: ", f, ". Check the 'Download source data' step.")
+}
 seasonal_xrapm <- read_parquet("source/seasonal_xrapm.parquet")
 seasonal_spm <- read_parquet("source/seasonal_spm.parquet")
 
@@ -25,6 +28,7 @@ spm <- seasonal_spm |>
   ungroup() |>
   select(player_name, spm_overall = spm)
 
+n_before <- nrow(xrapm)
 panna_ratings <- xrapm |>
   left_join(spm, by = "player_name") |>
   mutate(
@@ -42,7 +46,11 @@ panna_ratings <- xrapm |>
 na_spm <- sum(is.na(panna_ratings$spm_overall))
 cat("SPM join:", nrow(panna_ratings) - na_spm, "/", nrow(panna_ratings),
     "matched (", round(100 * na_spm / nrow(panna_ratings), 1), "% missing)\n")
-stopifnot(nrow(panna_ratings) > 0, na_spm / nrow(panna_ratings) < 0.2)
+stopifnot(
+  nrow(panna_ratings) == n_before,
+  nrow(panna_ratings) > 0,
+  na_spm / nrow(panna_ratings) < 0.2
+)
 
 dir.create("blog", showWarnings = FALSE)
 write_parquet(panna_ratings, "blog/panna_ratings.parquet")

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -18,17 +18,15 @@ xrapm <- seasonal_xrapm |>
   slice_max(total_minutes, n = 1, with_ties = FALSE) |>
   ungroup()
 
-join_key <- if ("player_id" %in% names(seasonal_spm) && "player_id" %in% names(seasonal_xrapm)) c("player_name", "player_id") else "player_name"
-
 spm <- seasonal_spm |>
   filter(season_end_year == latest_season) |>
   group_by(player_name) |>
   slice_max(total_minutes, n = 1, with_ties = FALSE) |>
   ungroup() |>
-  select(any_of(c("player_name", "player_id")), spm_overall = spm)
+  select(player_name, spm_overall = spm)
 
 panna_ratings <- xrapm |>
-  left_join(spm, by = join_key) |>
+  left_join(spm, by = "player_name") |>
   mutate(
     panna_rank = as.integer(rank(-xrapm, ties.method = "min")),
     panna_percentile = round(100 * rank(xrapm, ties.method = "min") / n(), 1)

--- a/scripts/opta/consolidate_opta.py
+++ b/scripts/opta/consolidate_opta.py
@@ -136,8 +136,8 @@ def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
         if backup_created and backup_file.exists():
             try:
                 backup_file.unlink()
-            except OSError:
-                pass  # Leftover backup is harmless; next run overwrites it
+            except OSError as e:
+                logger.debug("Could not remove backup %s: %s (harmless)", backup_file, e)
 
         size_mb = output_file.stat().st_size / (1024 * 1024)
         print(f"  {league}: {len(parquet_files)} seasons, {len(combined):,} rows, {size_mb:.1f}MB")
@@ -278,8 +278,8 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
         if backup_created and backup_file.exists():
             try:
                 backup_file.unlink()
-            except OSError:
-                pass  # Leftover backup is harmless; next run overwrites it
+            except OSError as e:
+                logger.debug("Could not remove backup %s: %s (harmless)", backup_file, e)
 
         size_mb = output_file.stat().st_size / (1024 * 1024)
         print(f"  Wrote {output_file}: {len(combined):,} rows, {size_mb:.1f} MB "
@@ -411,7 +411,7 @@ if __name__ == "__main__":
         catalog_errors = generate_catalog()
         if catalog_errors:
             logger.warning("Catalog generation had errors")
-    except (OSError, ValueError, KeyError, pd.errors.ParserError, pyarrow.lib.ArrowInvalid) as e:
+    except (OSError, ValueError, KeyError, TypeError, pd.errors.ParserError, pyarrow.lib.ArrowInvalid) as e:
         logger.warning("Catalog generation failed: %s", e, exc_info=True)
 
     if errors:

--- a/scripts/opta/consolidate_opta.py
+++ b/scripts/opta/consolidate_opta.py
@@ -411,7 +411,7 @@ if __name__ == "__main__":
         catalog_errors = generate_catalog()
         if catalog_errors:
             logger.warning("Catalog generation had errors")
-    except Exception as e:
+    except (OSError, ValueError, KeyError, pd.errors.ParserError, pyarrow.lib.ArrowInvalid) as e:
         logger.warning("Catalog generation failed: %s", e, exc_info=True)
 
     if errors:

--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -493,6 +493,7 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
                 combined.to_parquet(output_path, index=False)
             except (OSError, pyarrow.lib.ArrowInvalid) as e:
                 logger.error("Failed to write %s: %s", output_path, e)
+                return pd.DataFrame()
         return combined
 
     # Combine and save all data types
@@ -536,9 +537,10 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
         fixture_path = output_dirs["fixtures"] / f"{season_name}.parquet"
         try:
             fixture_df.to_parquet(fixture_path, index=False)
+            results["fixtures"] = fixture_df
         except (OSError, pyarrow.lib.ArrowInvalid) as e:
             logger.error("Failed to write fixtures %s: %s", fixture_path, e)
-        results["fixtures"] = fixture_df
+            results["fixtures"] = pd.DataFrame()
         print(f"\n  Fixtures: {len(fixture_df)} matches ({fixture_df['match_status'].value_counts().to_dict()})")
     else:
         results["fixtures"] = pd.DataFrame()

--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -391,7 +391,7 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
             # Get matchstats data
             stats = scraper.get_match_stats(match_id)
             if not stats:
-                print("FAILED (stats)")
+                logger.warning("No stats data for match %s (%s). Skipping.", match_id, match_desc)
                 continue
 
             existing_match_ids.add(match_id)
@@ -484,6 +484,7 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
                     logger.error("Moved corrupt file to %s", corrupt_path)
                 except OSError as rename_err:
                     logger.warning("Could not move corrupt file %s aside: %s", output_path, rename_err)
+                logger.warning("Writing %d new records only — historical data from %s is lost", len(new_df), output_path)
                 combined = new_df
         else:
             combined = new_df
@@ -538,10 +539,10 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
         try:
             fixture_df.to_parquet(fixture_path, index=False)
             results["fixtures"] = fixture_df
+            print(f"\n  Fixtures: {len(fixture_df)} matches ({fixture_df['match_status'].value_counts().to_dict()})")
         except (OSError, pyarrow.lib.ArrowInvalid) as e:
             logger.error("Failed to write fixtures %s: %s", fixture_path, e)
             results["fixtures"] = pd.DataFrame()
-        print(f"\n  Fixtures: {len(fixture_df)} matches ({fixture_df['match_status'].value_counts().to_dict()})")
     else:
         results["fixtures"] = pd.DataFrame()
 
@@ -676,15 +677,9 @@ def main():
             results.append(result)
             # Collect manifest records from this season
             all_new_manifest_records.extend(result.get("manifest_records", []))
-        except (requests.RequestException, ValueError, OSError) as e:
+        except (requests.RequestException, ValueError, OSError, KeyError,
+                TypeError, AttributeError, IndexError) as e:
             logger.error("Failed scraping %s %s: %s", league, season_name, e, exc_info=True)
-            results.append({
-                "competition": league,
-                "season": season_name,
-                "error": str(e)
-            })
-        except Exception as e:
-            logger.error("Unexpected error scraping %s %s: %s", league, season_name, e, exc_info=True)
             results.append({
                 "competition": league,
                 "season": season_name,


### PR DESCRIPTION
## Summary

- **Blog data pipeline**: Added `build_blog_data.R` + GHA workflow to build `panna_ratings.parquet` from seasonal ratings and upload to R2
- **SPM join fix**: Fixed 100% join failure in `build_blog_data.R` — composite join on `player_name + player_id` failed because `player_id` has different semantics in SPM vs xRAPM pipelines. Now joins on `player_name` only (~97% match rate). See panna#17 for deeper standardization work.
- **Scraper hardening**: Skip unchanged leagues in consolidation, better error handling, data safety guards
- **Docs**: Rewrote data dictionary with Opta as primary source, added blog data setup instructions
- **Opta catalog**: Added competition discovery and config files

## Test plan

- [x] `build-blog-data` GHA workflow passes (verified in this session)
- [x] Local join test confirms 96.7% match rate, zero duplicates
- [ ] Verify R2 upload contains valid `panna_ratings.parquet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)