### PR TITLE
Update wrangler v4 + --remote for R2 uploads

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -46,7 +46,7 @@ jobs:
           fi
           upload_errors=0
           for f in blog/*.parquet; do
-            if wrangler r2 object put "inthegame-data/$(basename $f)" --file "$f"; then
+            if wrangler r2 object put "inthegame-data/$(basename $f)" --file "$f" --remote; then
               echo "Uploaded $(basename $f)"
             else
               echo "ERROR: Failed to upload $(basename $f)"

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -39,7 +39,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_R2_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          npm install -g wrangler@3
+          npm install -g wrangler
           if ! ls blog/*.parquet 1>/dev/null 2>&1; then
             echo "ERROR: No parquet files found in blog/"
             exit 1


### PR DESCRIPTION
## Summary
- Upgrade wrangler from v3 to v4 (v3 returns 403 with Account API Tokens)
- Add `--remote` flag to `r2 object put` (v4 defaults to local dev mode)

## Test plan
- [x] Workflow ran successfully on `dev` — parquets uploaded to R2 and accessible via public URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)