### PR TITLE
Fix ArrowTypeError from mixed score columns + add shot data extraction

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -43,8 +43,12 @@ jobs:
           ls -lh blog/ source/
 
       - name: Build shot parquet
-        run: Rscript scripts/build_shot_data.R
-        continue-on-error: true
+        run: |
+          if [ -f source/opta_shot_events.parquet ]; then
+            Rscript scripts/build_shot_data.R
+          else
+            echo "::notice::Skipping shot data — source file not available"
+          fi
 
       - name: Upload to R2
         env:

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -14,15 +14,37 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            any::arrow
+            any::dplyr
+
       - name: Download blog data
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          mkdir -p blog
+          mkdir -p blog source
           gh release download blog-latest -p "panna_ratings.parquet" -D blog/ || { echo "ERROR: Failed to download panna_ratings.parquet from blog-latest"; exit 1; }
           gh release download blog-latest -p "match_predictions.parquet" -D blog/ || { echo "ERROR: Failed to download match_predictions.parquet from blog-latest"; exit 1; }
+
+          # Opta shot events (optional — doesn't fail build)
+          if gh release download opta-latest -p "opta_shot_events.parquet" -D source/; then
+            echo "Downloaded opta_shot_events.parquet"
+          else
+            echo "::warning::No opta shot events available, shot charts will be skipped"
+          fi
+
           echo "Downloaded blog data:"
-          ls -lh blog/
+          ls -lh blog/ source/
+
+      - name: Build shot parquet
+        run: Rscript scripts/build_shot_data.R
+        continue-on-error: true
 
       - name: Upload to R2
         env:

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -74,3 +74,34 @@ stopifnot(
 dir.create("blog", showWarnings = FALSE)
 write_parquet(panna_ratings, "blog/panna_ratings.parquet")
 cat("panna_ratings:", nrow(panna_ratings), "players (season", latest_season, ")\n")
+
+# Shot data from Opta — wrapped in tryCatch so missing opta data doesn't block core build
+tryCatch({
+  opta_path <- "source/opta_shot_events.parquet"
+  if (!file.exists(opta_path)) stop("opta_shot_events.parquet not found in source/")
+
+  opta_shots <- read_parquet(opta_path)
+
+  tracked_leagues <- c("EPL", "La_Liga", "Serie_A", "Bundesliga", "Ligue_1", "UCL", "UEL")
+  recent_seasons <- sort(unique(opta_shots$season[opta_shots$competition %in% tracked_leagues]),
+                         decreasing = TRUE)[1:5]
+
+  panna_shots <- opta_shots |>
+    filter(competition %in% tracked_leagues, season %in% recent_seasons) |>
+    transmute(
+      player_name,
+      x = round(x, 1),
+      y = round(y, 1),
+      is_goal,
+      type_id = as.integer(type_id),
+      body_part,
+      situation,
+      season
+    )
+
+  write_parquet(panna_shots, "blog/panna_shots.parquet")
+  cat("panna_shots:", nrow(panna_shots), "shots across", length(recent_seasons), "seasons\n")
+}, error = function(e) {
+  cat("WARNING: Shot data extraction failed, skipping panna_shots.parquet:",
+      conditionMessage(e), "\n")
+})

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -75,33 +75,10 @@ dir.create("blog", showWarnings = FALSE)
 write_parquet(panna_ratings, "blog/panna_ratings.parquet")
 cat("panna_ratings:", nrow(panna_ratings), "players (season", latest_season, ")\n")
 
-# Shot data from Opta — wrapped in tryCatch so missing opta data doesn't block core build
+# Shot data from Opta — wrapped in tryCatch so shot extraction failure doesn't affect script exit code
 tryCatch({
-  opta_path <- "source/opta_shot_events.parquet"
-  if (!file.exists(opta_path)) stop("opta_shot_events.parquet not found in source/")
-
-  opta_shots <- read_parquet(opta_path)
-
-  tracked_leagues <- c("EPL", "La_Liga", "Serie_A", "Bundesliga", "Ligue_1", "UCL", "UEL")
-  recent_seasons <- sort(unique(opta_shots$season[opta_shots$competition %in% tracked_leagues]),
-                         decreasing = TRUE)[1:5]
-
-  panna_shots <- opta_shots |>
-    filter(competition %in% tracked_leagues, season %in% recent_seasons) |>
-    transmute(
-      player_name,
-      x = round(x, 1),
-      y = round(y, 1),
-      is_goal,
-      type_id = as.integer(type_id),
-      body_part,
-      situation,
-      season
-    )
-
-  write_parquet(panna_shots, "blog/panna_shots.parquet")
-  cat("panna_shots:", nrow(panna_shots), "shots across", length(recent_seasons), "seasons\n")
+  source("scripts/build_shot_data.R")
 }, error = function(e) {
-  cat("WARNING: Shot data extraction failed, skipping panna_shots.parquet:",
-      conditionMessage(e), "\n")
+  message("WARNING: Shot data extraction failed, skipping panna_shots.parquet: ",
+          conditionMessage(e))
 })

--- a/scripts/build_shot_data.R
+++ b/scripts/build_shot_data.R
@@ -1,3 +1,7 @@
+# build_shot_data.R — Extract recent shot data from Opta for shot chart feature.
+# Can be run standalone (Rscript scripts/build_shot_data.R) or source()'d from
+# build_blog_data.R (where tryCatch prevents shot failures from blocking ratings).
+
 library(arrow)
 library(dplyr)
 
@@ -22,6 +26,8 @@ panna_shots <- opta_shots |>
     situation,
     season
   )
+
+stopifnot(nrow(panna_shots) > 0, length(recent_seasons) > 0)
 
 dir.create("blog", showWarnings = FALSE)
 write_parquet(panna_shots, "blog/panna_shots.parquet")

--- a/scripts/build_shot_data.R
+++ b/scripts/build_shot_data.R
@@ -1,0 +1,28 @@
+library(arrow)
+library(dplyr)
+
+opta_path <- "source/opta_shot_events.parquet"
+if (!file.exists(opta_path)) stop("opta_shot_events.parquet not found in source/")
+
+opta_shots <- read_parquet(opta_path)
+
+tracked_leagues <- c("EPL", "La_Liga", "Serie_A", "Bundesliga", "Ligue_1", "UCL", "UEL")
+recent_seasons <- sort(unique(opta_shots$season[opta_shots$competition %in% tracked_leagues]),
+                       decreasing = TRUE)[1:5]
+
+panna_shots <- opta_shots |>
+  filter(competition %in% tracked_leagues, season %in% recent_seasons) |>
+  transmute(
+    player_name,
+    x = round(x, 1),
+    y = round(y, 1),
+    is_goal,
+    type_id = as.integer(type_id),
+    body_part,
+    situation,
+    season
+  )
+
+dir.create("blog", showWarnings = FALSE)
+write_parquet(panna_shots, "blog/panna_shots.parquet")
+cat("panna_shots:", nrow(panna_shots), "shots across", length(recent_seasons), "seasons\n")

--- a/scripts/opta/consolidate_opta.py
+++ b/scripts/opta/consolidate_opta.py
@@ -175,6 +175,17 @@ def _cleanup_temp_dir(temp_dir):
         print(f"  WARNING: Could not clean up temp dir {temp_dir}: {e}")
 
 
+def _cast_mixed_to_string(col):
+    """Cast object-dtype column to string, preserving nulls.
+
+    Whole floats become '2' not '2.0' — important for columns like score
+    that may contain a mix of int, float, and string values across seasons.
+    """
+    return col.where(col.isna(), col.apply(
+        lambda v: str(int(v)) if isinstance(v, float) and v == int(v) else str(v)
+    ))
+
+
 def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
     """Consolidate match_events by league (too large for single file).
 
@@ -333,12 +344,14 @@ def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
             # Append new data
             if new_df is not None and not new_df.empty:
                 # Cast mixed-type columns to string before PyArrow conversion
+                # (unified schema may specify string for columns with type conflicts,
+                # e.g. score columns that are int in some seasons and string in others)
                 if unified_schema is not None:
                     for field in unified_schema:
                         if field.type == pa.string() and field.name in new_df.columns:
                             col = new_df[field.name]
                             if col.dtype == object:
-                                new_df[field.name] = col.where(col.isna(), col.astype(str))
+                                new_df[field.name] = _cast_mixed_to_string(col)
                 new_table = pa.Table.from_pandas(new_df, preserve_index=False)
                 del new_df
                 new_table = _align_table(new_table, unified_schema)
@@ -569,13 +582,14 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
                         print(f"    {league}: removed {dupes:,} duplicates")
 
                 # Cast mixed-type columns to string before PyArrow conversion
-                # (unified schema may specify string for columns with type conflicts)
+                # (unified schema may specify string for columns with type conflicts,
+                # e.g. score columns that are int in some seasons and string in others)
                 if unified_schema is not None:
                     for field in unified_schema:
                         if field.type == pa.string() and field.name in league_df.columns:
                             col = league_df[field.name]
                             if col.dtype == object:
-                                league_df[field.name] = col.where(col.isna(), col.astype(str))
+                                league_df[field.name] = _cast_mixed_to_string(col)
 
                 # Convert to PyArrow and align schema
                 table = pa.Table.from_pandas(league_df, preserve_index=False)

--- a/scripts/opta/consolidate_opta.py
+++ b/scripts/opta/consolidate_opta.py
@@ -332,6 +332,13 @@ def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
 
             # Append new data
             if new_df is not None and not new_df.empty:
+                # Cast mixed-type columns to string before PyArrow conversion
+                if unified_schema is not None:
+                    for field in unified_schema:
+                        if field.type == pa.string() and field.name in new_df.columns:
+                            col = new_df[field.name]
+                            if col.dtype == object:
+                                new_df[field.name] = col.where(col.isna(), col.astype(str))
                 new_table = pa.Table.from_pandas(new_df, preserve_index=False)
                 del new_df
                 new_table = _align_table(new_table, unified_schema)
@@ -560,6 +567,15 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
                     dupes = before - len(league_df)
                     if dupes > 0:
                         print(f"    {league}: removed {dupes:,} duplicates")
+
+                # Cast mixed-type columns to string before PyArrow conversion
+                # (unified schema may specify string for columns with type conflicts)
+                if unified_schema is not None:
+                    for field in unified_schema:
+                        if field.type == pa.string() and field.name in league_df.columns:
+                            col = league_df[field.name]
+                            if col.dtype == object:
+                                league_df[field.name] = col.where(col.isna(), col.astype(str))
 
                 # Convert to PyArrow and align schema
                 table = pa.Table.from_pandas(league_df, preserve_index=False)


### PR DESCRIPTION
## Summary

- **Fix ArrowTypeError**: Extract `_cast_mixed_to_string()` helper in `consolidate_opta.py` that produces clean integer strings for whole numbers (e.g., `"2"` not `"2.0"`). Applied at both call sites (events and non-events consolidation).
- **Add shot data extraction**: New `build_shot_data.R` script extracts recent Opta shot events for shot chart feature, integrated into `build-blog-data.yml` workflow and `build_blog_data.R`.
- **Eliminate duplicated shot logic**: `build_blog_data.R` now `source()`s `build_shot_data.R` instead of duplicating 30 lines of shot extraction code.
- **Replace `continue-on-error: true`**: Workflow now conditionally skips the shot step when the source file is missing (expected) but fails loudly on script errors (unexpected).
- **Add output validation**: `stopifnot()` in `build_shot_data.R` catches silent empty output from changed league names.

## Test plan

- [ ] Verify `consolidate_opta.py` helper handles: NaN → preserved, 2.0 → "2", "abc" → "abc", None → preserved
- [ ] Verify `build_shot_data.R` can be `source()`'d from `build_blog_data.R` (both use `library(arrow)` + `library(dplyr)` — no conflict)
- [ ] Verify workflow skips shot step when `opta_shot_events.parquet` is absent
- [ ] Verify workflow fails on R script errors when source file exists
- [ ] `git diff` confirms no unintended changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)