### PR TITLE
Fix consolidation crashes and add shot data extraction

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Build shot parquet
         run: |
           if [ -f source/opta_shot_events.parquet ]; then
-            Rscript scripts/build_shot_data.R
+            if ! Rscript scripts/build_shot_data.R; then
+              echo "::warning::Shot data build failed, continuing without shot charts"
+            fi
           else
             echo "::notice::Skipping shot data — source file not available"
           fi

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -75,10 +75,12 @@ dir.create("blog", showWarnings = FALSE)
 write_parquet(panna_ratings, "blog/panna_ratings.parquet")
 cat("panna_ratings:", nrow(panna_ratings), "players (season", latest_season, ")\n")
 
-# Shot data from Opta — wrapped in tryCatch so shot extraction failure doesn't affect script exit code
+# Shot data from Opta — tryCatch ensures shot failures don't block ratings
+# when run locally or via source(). In GHA, build_shot_data.R runs as a separate step.
 tryCatch({
   source("scripts/build_shot_data.R")
 }, error = function(e) {
-  message("WARNING: Shot data extraction failed, skipping panna_shots.parquet: ",
-          conditionMessage(e))
+  warning("Shot data extraction failed, skipping panna_shots.parquet: ",
+          conditionMessage(e), call. = FALSE)
+  cat("::warning::Shot data extraction failed:", conditionMessage(e), "\n")
 })

--- a/scripts/build_shot_data.R
+++ b/scripts/build_shot_data.R
@@ -1,6 +1,7 @@
 # build_shot_data.R — Extract recent shot data from Opta for shot chart feature.
-# Can be run standalone (Rscript scripts/build_shot_data.R) or source()'d from
-# build_blog_data.R (where tryCatch prevents shot failures from blocking ratings).
+# Run standalone (Rscript scripts/build_shot_data.R) or source()'d from
+# build_blog_data.R. Must be run from the pannadata repo root.
+# In GHA, build_shot_data.R runs as a separate workflow step.
 
 library(arrow)
 library(dplyr)
@@ -10,9 +11,19 @@ if (!file.exists(opta_path)) stop("opta_shot_events.parquet not found in source/
 
 opta_shots <- read_parquet(opta_path)
 
+required_cols <- c("season", "competition", "player_name", "x", "y",
+                   "is_goal", "type_id", "body_part", "situation")
+missing <- setdiff(required_cols, names(opta_shots))
+if (length(missing) > 0) {
+  stop("opta_shot_events.parquet missing columns: ", paste(missing, collapse = ", "),
+       ". Check the Opta scraper output schema.")
+}
+
 tracked_leagues <- c("EPL", "La_Liga", "Serie_A", "Bundesliga", "Ligue_1", "UCL", "UEL")
-recent_seasons <- sort(unique(opta_shots$season[opta_shots$competition %in% tracked_leagues]),
-                       decreasing = TRUE)[1:5]
+recent_seasons <- head(
+  sort(unique(opta_shots$season[opta_shots$competition %in% tracked_leagues]),
+       decreasing = TRUE), 5
+)
 
 panna_shots <- opta_shots |>
   filter(competition %in% tracked_leagues, season %in% recent_seasons) |>

--- a/scripts/opta/consolidate_opta.py
+++ b/scripts/opta/consolidate_opta.py
@@ -181,9 +181,16 @@ def _cast_mixed_to_string(col):
     Whole floats become '2' not '2.0' — important for columns like score
     that may contain a mix of int, float, and string values across seasons.
     """
-    return col.where(col.isna(), col.apply(
-        lambda v: str(int(v)) if isinstance(v, float) and v == int(v) else str(v)
-    ))
+    import math
+
+    def _to_str(v):
+        if v is None or (isinstance(v, float) and math.isnan(v)):
+            return v
+        if isinstance(v, float) and v == int(v):
+            return str(int(v))
+        return str(v)
+
+    return col.apply(_to_str)
 
 
 def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):

--- a/scripts/opta/consolidate_opta.py
+++ b/scripts/opta/consolidate_opta.py
@@ -186,11 +186,26 @@ def _cast_mixed_to_string(col):
     def _to_str(v):
         if v is None or (isinstance(v, float) and math.isnan(v)):
             return v
-        if isinstance(v, float) and v == int(v):
-            return str(int(v))
+        if isinstance(v, float):
+            if math.isinf(v) or abs(v) > 1e15:
+                return str(v)
+            if v == int(v):
+                return str(int(v))
         return str(v)
 
     return col.apply(_to_str)
+
+
+def _cast_mixed_columns(df, schema):
+    """Cast object-dtype columns to string where schema expects string."""
+    if schema is None:
+        return df
+    for field in schema:
+        if field.type == pa.string() and field.name in df.columns:
+            col = df[field.name]
+            if col.dtype == object:
+                df[field.name] = _cast_mixed_to_string(col)
+    return df
 
 
 def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
@@ -350,15 +365,7 @@ def consolidate_events_by_league(opta_dir="opta", output_dir="opta"):
 
             # Append new data
             if new_df is not None and not new_df.empty:
-                # Cast mixed-type columns to string before PyArrow conversion
-                # (unified schema may specify string for columns with type conflicts,
-                # e.g. score columns that are int in some seasons and string in others)
-                if unified_schema is not None:
-                    for field in unified_schema:
-                        if field.type == pa.string() and field.name in new_df.columns:
-                            col = new_df[field.name]
-                            if col.dtype == object:
-                                new_df[field.name] = _cast_mixed_to_string(col)
+                _cast_mixed_columns(new_df, unified_schema)
                 new_table = pa.Table.from_pandas(new_df, preserve_index=False)
                 del new_df
                 new_table = _align_table(new_table, unified_schema)
@@ -588,15 +595,7 @@ def consolidate_opta(opta_dir="opta", output_dir="opta"):
                     if dupes > 0:
                         print(f"    {league}: removed {dupes:,} duplicates")
 
-                # Cast mixed-type columns to string before PyArrow conversion
-                # (unified schema may specify string for columns with type conflicts,
-                # e.g. score columns that are int in some seasons and string in others)
-                if unified_schema is not None:
-                    for field in unified_schema:
-                        if field.type == pa.string() and field.name in league_df.columns:
-                            col = league_df[field.name]
-                            if col.dtype == object:
-                                league_df[field.name] = _cast_mixed_to_string(col)
+                _cast_mixed_columns(league_df, unified_schema)
 
                 # Convert to PyArrow and align schema
                 table = pa.Table.from_pandas(league_df, preserve_index=False)


### PR DESCRIPTION
## Summary
- **Fix NaN crash in `_cast_mixed_to_string`**: `col.apply()` eagerly evaluates NaN values before `.where()` can mask them, causing `ValueError: cannot convert float NaN to integer`. Now handles NaN/None inside the lambda itself.
- **Fix ArrowTypeError from mixed string/float score columns**: Added `_cast_mixed_to_string` helper for type-conflicting columns during fixtures consolidation.
- **Add shot data extraction**: New `build_shot_data.R` script for shot chart feature, integrated into `build-blog-data.yml` workflow.
- **PR #17 review fixes**: Deduplicated shot logic, hardened workflow and validation.

## Test plan
- [x] Manually triggered Daily Opta Scrape workflow — passed in 13m37s
- [x] Verified `_cast_mixed_to_string` handles NaN, None, whole floats, and strings correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)