### PR TITLE
Add player skills R2 upload to build-blog-data

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -52,6 +52,24 @@ jobs:
             echo "::notice::Skipping shot data — source file not available"
           fi
 
+      - name: Download and filter player skills
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release download opta-latest -p "opta_skills.parquet" -D source/; then
+            Rscript -e '
+              library(arrow)
+              library(dplyr)
+              df <- read_parquet("source/opta_skills.parquet")
+              latest <- df |> filter(season_end_year == max(season_end_year))
+              if (nrow(latest) == 0) stop("Filter produced 0 rows -- aborting")
+              write_parquet(latest, "blog/panna_player_skills.parquet")
+              cat(sprintf("Filtered to season %d: %d players\n", max(df$season_end_year), nrow(latest)))
+            '
+          else
+            echo "::warning::opta_skills.parquet not available — player skills won't update"
+          fi
+
       - name: Upload to R2
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_R2_TOKEN }}


### PR DESCRIPTION
## Summary
- Download opta_skills.parquet, filter to latest season, output as panna_player_skills.parquet for R2 upload
- Previously this lived in inthegame-blog/refresh-data.yml as a middleman step
- Also includes prior shot data pipeline hardening from earlier PRs

## Test plan
- [ ] Trigger build-blog-data manually → verify panna_player_skills.parquet appears on R2
- [ ] Confirm existing panna_ratings, match_predictions, and panna_shots uploads still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)