### PR TITLE
Add UCL, UEL, Conference League to blog data pipeline

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -174,6 +174,49 @@ jobs:
             echo "::notice::Skipping league-xg — match-shots not available"
           fi
 
+      - name: Enrich predictions with match-level xG
+        continue-on-error: true
+        run: |
+          if [ -f blog/match-shots.parquet ] && [ -f blog/predictions.parquet ]; then
+            Rscript -e '
+              library(arrow); library(dplyr)
+              ms <- read_parquet("blog/match-shots.parquet")
+              if (!"xg" %in% names(ms) || all(is.na(ms$xg))) {
+                cat("No xG in match-shots — skipping predictions enrichment\n"); q()
+              }
+              # Per-match, per-team xG totals
+              team_xg <- ms |> filter(!is.na(xg)) |>
+                group_by(match_id, team_id) |>
+                summarise(xg = round(sum(xg, na.rm = TRUE), 2), .groups = "drop")
+              # Get home/away from match-stats team_position
+              codes <- c("ENG","ENG2","ESP","FRA","GER","ITA","NED","POR","SCO","TUR")
+              pos <- list()
+              for (code in codes) {
+                f <- paste0("blog/match-stats-", code, ".parquet")
+                if (file.exists(f)) {
+                  pos[[code]] <- read_parquet(f, col_select = c("match_id","team_id","team_position")) |>
+                    distinct(match_id, team_id, team_position)
+                }
+              }
+              pos <- bind_rows(pos)
+              # Pivot to one row per match: xg_home, xg_away
+              match_xg <- team_xg |>
+                inner_join(pos, by = c("match_id", "team_id")) |>
+                filter(team_position %in% c("home", "away")) |>
+                tidyr::pivot_wider(id_cols = match_id, names_from = team_position,
+                  values_from = xg, names_prefix = "xg_")
+              # Enrich predictions
+              pred <- read_parquet("blog/predictions.parquet")
+              pred_enriched <- pred |>
+                left_join(match_xg |> select(match_id, xg_home, xg_away), by = "match_id")
+              write_parquet(pred_enriched, "blog/predictions.parquet")
+              n_xg <- sum(!is.na(pred_enriched$xg_home))
+              cat("predictions enriched:", n_xg, "/", nrow(pred_enriched), "matches have xG\n")
+            '
+          else
+            echo "::notice::Skipping predictions xG enrichment — required files not available"
+          fi
+
       - name: Build chain parquets (one league at a time)
         continue-on-error: true
         env:

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -131,8 +131,8 @@ jobs:
           if [ -f source/opta_shot_events.parquet ]; then
             Rscript -e '
               library(arrow); library(dplyr)
-              comps <- c("EPL","Championship","La_Liga","Ligue_1","Bundesliga","Serie_A","Eredivisie","Primeira_Liga","Scottish_Premiership","Super_Lig","UCL","UEL","Conference_League")
-              shots <- read_parquet("source/opta_shot_events.parquet") |> filter(competition %in% comps)
+              source("scripts/league_config.R")
+              shots <- read_parquet("source/opta_shot_events.parquet") |> filter(competition %in% BLOG_COMPS)
               has_xg <- "xg" %in% names(shots)
               cat("Source has xG:", has_xg, "\n")
               # Team names from lineups
@@ -175,12 +175,13 @@ jobs:
           if [ -f blog/match-shots.parquet ]; then
             Rscript -e '
               library(arrow); library(dplyr)
+              source("scripts/league_config.R")
               ms <- read_parquet("blog/match-shots.parquet")
               if (!"xg" %in% names(ms) || all(is.na(ms$xg))) {
                 cat("No xG in match-shots — skipping league-xg\n"); q()
               }
               # Read match-stats per league for match_id → league/season mapping
-              codes <- c("ENG","ENG2","ESP","FRA","GER","ITA","NED","POR","SCO","TUR","UCL","UEL","UECL")
+              codes <- BLOG_CODES
               meta <- list()
               for (code in codes) {
                 f <- paste0("blog/match-stats-", code, ".parquet")
@@ -212,6 +213,7 @@ jobs:
           if [ -f blog/match-shots.parquet ] && [ -f blog/predictions.parquet ]; then
             Rscript -e '
               library(arrow); library(dplyr)
+              source("scripts/league_config.R")
               ms <- read_parquet("blog/match-shots.parquet")
               if (!"xg" %in% names(ms) || all(is.na(ms$xg))) {
                 cat("No xG in match-shots — skipping predictions enrichment\n"); q()
@@ -221,7 +223,7 @@ jobs:
                 group_by(match_id, team_id) |>
                 summarise(xg = round(sum(xg, na.rm = TRUE), 2), .groups = "drop")
               # Get home/away from match-stats team_position
-              codes <- c("ENG","ENG2","ESP","FRA","GER","ITA","NED","POR","SCO","TUR","UCL","UEL","UECL")
+              codes <- BLOG_CODES
               pos <- list()
               for (code in codes) {
                 f <- paste0("blog/match-stats-", code, ".parquet")

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -41,6 +41,21 @@ jobs:
           gh release download blog-latest -p "match_predictions.parquet" -D blog/ || { echo "ERROR: Failed to download match_predictions.parquet from blog-latest"; exit 1; }
           mv blog/match_predictions.parquet blog/predictions.parquet
 
+          # Game logs (per-match player value metrics — optional, pass through to R2)
+          if gh release download blog-latest -p "game_logs.parquet" -D blog/; then
+            mv blog/game_logs.parquet blog/game-logs.parquet
+            echo "Downloaded game-logs.parquet"
+          else
+            echo "::warning::game_logs.parquet not available — Value tab will be empty"
+          fi
+
+          # Action equity (per-action EPV credit — optional, used by chain builder)
+          if gh release download blog-latest -p "action_equity.parquet" -D source/; then
+            echo "Downloaded action_equity.parquet"
+          else
+            echo "::warning::action_equity.parquet not available — chains will lack equity"
+          fi
+
           # Opta shot events (optional — doesn't fail build)
           if gh release download opta-latest -p "opta_shot_events.parquet" -D source/; then
             echo "Downloaded opta_shot_events.parquet"
@@ -65,6 +80,15 @@ jobs:
 
       - name: Build ratings parquet
         run: Rscript scripts/build_blog_data.R
+
+      - name: Build player details parquet
+        continue-on-error: true
+        run: |
+          if [ -f source/opta_lineups.parquet ]; then
+            Rscript scripts/build_player_meta.R
+          else
+            echo "::notice::Skipping player details — lineups file not available"
+          fi
 
       - name: Build shot parquet
         run: |

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -131,7 +131,7 @@ jobs:
           if [ -f source/opta_shot_events.parquet ]; then
             Rscript -e '
               library(arrow); library(dplyr)
-              comps <- c("EPL","Championship","La_Liga","Ligue_1","Bundesliga","Serie_A","Eredivisie","Primeira_Liga","Scottish_Premiership","Super_Lig")
+              comps <- c("EPL","Championship","La_Liga","Ligue_1","Bundesliga","Serie_A","Eredivisie","Primeira_Liga","Scottish_Premiership","Super_Lig","UCL","UEL","Conference_League")
               shots <- read_parquet("source/opta_shot_events.parquet") |> filter(competition %in% comps)
               has_xg <- "xg" %in% names(shots)
               cat("Source has xG:", has_xg, "\n")
@@ -180,7 +180,7 @@ jobs:
                 cat("No xG in match-shots — skipping league-xg\n"); q()
               }
               # Read match-stats per league for match_id → league/season mapping
-              codes <- c("ENG","ENG2","ESP","FRA","GER","ITA","NED","POR","SCO","TUR")
+              codes <- c("ENG","ENG2","ESP","FRA","GER","ITA","NED","POR","SCO","TUR","UCL","UEL","UECL")
               meta <- list()
               for (code in codes) {
                 f <- paste0("blog/match-stats-", code, ".parquet")
@@ -221,7 +221,7 @@ jobs:
                 group_by(match_id, team_id) |>
                 summarise(xg = round(sum(xg, na.rm = TRUE), 2), .groups = "drop")
               # Get home/away from match-stats team_position
-              codes <- c("ENG","ENG2","ESP","FRA","GER","ITA","NED","POR","SCO","TUR")
+              codes <- c("ENG","ENG2","ESP","FRA","GER","ITA","NED","POR","SCO","TUR","UCL","UEL","UECL")
               pos <- list()
               for (code in codes) {
                 f <- paste0("blog/match-stats-", code, ".parquet")

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -24,6 +24,7 @@ jobs:
           packages: |
             any::arrow
             any::dplyr
+            any::tidyr
 
       - name: Download source data
         env:

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -41,6 +41,13 @@ jobs:
           gh release download blog-latest -p "match_predictions.parquet" -D blog/ || { echo "ERROR: Failed to download match_predictions.parquet from blog-latest"; exit 1; }
           mv blog/match_predictions.parquet blog/predictions.parquet
 
+          # Season standings (for simulation script — optional)
+          if gh release download blog-latest -p "season_standings.parquet" -D blog/; then
+            echo "Downloaded season_standings.parquet"
+          else
+            echo "::warning::season_standings.parquet not available — simulations will lack current standings"
+          fi
+
           # Game logs (per-match player value metrics — optional, pass through to R2)
           if gh release download blog-latest -p "game_logs.parquet" -D blog/; then
             mv blog/game_logs.parquet blog/game-logs.parquet

--- a/scripts/build_chains_ci.R
+++ b/scripts/build_chains_ci.R
@@ -15,6 +15,16 @@ dir.create(out_dir, showWarnings = FALSE)
 cat("=== Chain Builder (CI) ===\n")
 cat("Memory:", round(as.numeric(system("free -m | awk '/Mem:/{print $2}'", intern = TRUE)), 0), "MB total\n\n")
 
+# Load equity lookup (optional — from panna predictions pipeline)
+equity_file <- file.path(src_dir, "action_equity.parquet")
+has_equity <- file.exists(equity_file)
+if (has_equity) {
+  equity_lookup <- read_parquet(equity_file)
+  cat("Equity loaded:", nrow(equity_lookup), "actions\n")
+} else {
+  cat("No equity file — chains will not include EPV credit\n")
+}
+
 # Load lineups once (shared across all leagues)
 lineup_file <- file.path(src_dir, "opta_lineups.parquet")
 if (!file.exists(lineup_file)) stop("Missing: ", lineup_file)
@@ -110,6 +120,7 @@ for (comp in blog_comps) {
     transmute(
       match_id, chain_number = as.integer(chain_number),
       display_order = as.integer(display_order),
+      event_id,
       player_id, player_name, team_id,
       x = round(x, 1), y = round(y, 1),
       end_x = round(end_x, 1), end_y = round(end_y, 1),
@@ -124,6 +135,15 @@ for (comp in blog_comps) {
     ) |>
     select(-any_of("team_name_lookup")) |>
     arrange(match_id, chain_number, display_order)
+
+  # Join EPV equity if available
+  if (has_equity) {
+    chains <- chains |>
+      left_join(equity_lookup |> select(match_id, event_id, equity),
+                by = c("match_id", "event_id"))
+    n_eq <- sum(!is.na(chains$equity))
+    cat("  equity: ", n_eq, "/", nrow(chains), " actions\n", sep = "")
+  }
 
   league_code <- comp_to_code[comp]
   out_path <- file.path(out_dir, paste0("chains-", league_code, ".parquet"))

--- a/scripts/build_chains_ci.R
+++ b/scripts/build_chains_ci.R
@@ -45,15 +45,9 @@ global_team_map <- lineups |> distinct(team_id, team_name) |>
 rm(lineups); gc(verbose = FALSE)
 cat("Lineups loaded:", nrow(match_teams), "matches\n\n")
 
-blog_comps <- c("EPL", "Championship", "La_Liga", "Ligue_1", "Bundesliga",
-                "Serie_A", "Eredivisie", "Primeira_Liga", "Scottish_Premiership",
-                "Super_Lig", "UCL", "UEL", "Conference_League")
-comp_to_code <- c(
-  EPL = "ENG", Championship = "ENG2", La_Liga = "ESP", Ligue_1 = "FRA",
-  Bundesliga = "GER", Serie_A = "ITA", Eredivisie = "NED",
-  Primeira_Liga = "POR", Scottish_Premiership = "SCO", Super_Lig = "TUR",
-  UCL = "UCL", UEL = "UEL", Conference_League = "UECL"
-)
+source("scripts/league_config.R")
+blog_comps <- BLOG_COMPS
+comp_to_code <- BLOG_COMP_TO_CODE
 dead_ball_types <- c(2L, 4L, 5L, 6L, 17L, 55L, 56L, 57L, 70L, 80L, 81L)
 non_play_types <- c(18L, 19L, 24L, 27L, 28L, 30L, 32L, 34L, 37L, 40L, 43L, 65L, 68L)
 shot_types <- c(13L, 14L, 15L, 16L)
@@ -143,7 +137,8 @@ for (comp in blog_comps) {
       left_join(equity_lookup |> select(match_id, event_id, equity),
                 by = c("match_id", "event_id"))
     n_eq <- sum(!is.na(chains$equity))
-    cat("  equity: ", n_eq, "/", nrow(chains), " actions\n", sep = "")
+    if (n_eq == 0) cat("  WARNING: equity join matched 0 actions (check event_id format)\n")
+    else cat("  equity: ", n_eq, "/", nrow(chains), " actions\n", sep = "")
   }
 
   league_code <- comp_to_code[comp]

--- a/scripts/build_chains_ci.R
+++ b/scripts/build_chains_ci.R
@@ -47,11 +47,12 @@ cat("Lineups loaded:", nrow(match_teams), "matches\n\n")
 
 blog_comps <- c("EPL", "Championship", "La_Liga", "Ligue_1", "Bundesliga",
                 "Serie_A", "Eredivisie", "Primeira_Liga", "Scottish_Premiership",
-                "Super_Lig")
+                "Super_Lig", "UCL", "UEL", "Conference_League")
 comp_to_code <- c(
   EPL = "ENG", Championship = "ENG2", La_Liga = "ESP", Ligue_1 = "FRA",
   Bundesliga = "GER", Serie_A = "ITA", Eredivisie = "NED",
-  Primeira_Liga = "POR", Scottish_Premiership = "SCO", Super_Lig = "TUR"
+  Primeira_Liga = "POR", Scottish_Premiership = "SCO", Super_Lig = "TUR",
+  UCL = "UCL", UEL = "UEL", Conference_League = "UECL"
 )
 dead_ball_types <- c(2L, 4L, 5L, 6L, 17L, 55L, 56L, 57L, 70L, 80L, 81L)
 non_play_types <- c(18L, 19L, 24L, 27L, 28L, 30L, 32L, 34L, 37L, 40L, 43L, 65L, 68L)

--- a/scripts/build_player_meta.R
+++ b/scripts/build_player_meta.R
@@ -1,7 +1,13 @@
 library(arrow)
 library(dplyr)
 
-lu <- read_parquet("data/opta/opta_lineups.parquet")
+# Support both local (data/opta/) and CI (source/) paths
+lu_path <- if (file.exists("source/opta_lineups.parquet")) {
+  "source/opta_lineups.parquet"
+} else {
+  "data/opta/opta_lineups.parquet"
+}
+lu <- read_parquet(lu_path)
 
 # Use the main league season format (e.g. "2024-2025"), not tournament seasons
 league_seasons <- grep("^\\d{4}-\\d{4}$", unique(lu$season), value = TRUE)
@@ -43,5 +49,5 @@ cat("Player metadata:", nrow(player_meta), "players\n")
 cat("Position coverage:", round(100 * mean(!is.na(player_meta$position)), 1), "%\n")
 
 dir.create("blog", showWarnings = FALSE)
-write_parquet(player_meta, "blog/player_metadata.parquet")
-cat("Saved blog/player_metadata.parquet\n")
+write_parquet(player_meta, "blog/player-details.parquet")
+cat("Saved blog/player-details.parquet\n")

--- a/scripts/league_config.R
+++ b/scripts/league_config.R
@@ -1,0 +1,13 @@
+# Shared league configuration — single source of truth for blog data pipeline.
+# Opta competition name → blog league code mapping.
+# Source this file from any script that needs the league list.
+
+BLOG_COMP_TO_CODE <- c(
+  EPL = "ENG", Championship = "ENG2", La_Liga = "ESP", Ligue_1 = "FRA",
+  Bundesliga = "GER", Serie_A = "ITA", Eredivisie = "NED",
+  Primeira_Liga = "POR", Scottish_Premiership = "SCO", Super_Lig = "TUR",
+  UCL = "UCL", UEL = "UEL", Conference_League = "UECL"
+)
+
+BLOG_COMPS <- names(BLOG_COMP_TO_CODE)
+BLOG_CODES <- unname(BLOG_COMP_TO_CODE)

--- a/scripts/opta/test_live_events.py
+++ b/scripts/opta/test_live_events.py
@@ -1,0 +1,164 @@
+"""
+Test whether Opta API serves live match event data.
+
+Run during a live match:
+  cd pannadata
+  python scripts/opta/test_live_events.py
+
+Or specify a known match ID:
+  python scripts/opta/test_live_events.py --match-id <id>
+"""
+import sys
+import json
+from datetime import datetime, timedelta
+from opta_scraper import OptaScraper
+
+scraper = OptaScraper()
+
+# Season IDs for leagues we want to test (add more as needed)
+SEASONS = {
+    "EPL": "51r6ph2woavlbbpk8f29nynf8",
+    "AFC CL Two": "bx57cmq1edfq53ckfk791supi",
+    "AFC CL Elite": "3qixixbgvsajit71o6mxb7x4a",
+    "A-League": "bi1u4m4xssntipznvmocabh39",
+    "La Liga": "eum3wxkqwgz7bhrk5kz7zu5ek",
+    "Serie A": "41cp0wg7b0ck2g85kpwtvdkm2",
+    "Bundesliga": "ajnp97j8msxafqbqyq3sd2s3e",
+    "Ligue 1": "bnh4b93kc4g5s2lv2kbvl3p22",
+}
+
+# Check for --match-id argument
+match_id = None
+if "--match-id" in sys.argv:
+    idx = sys.argv.index("--match-id")
+    if idx + 1 < len(sys.argv):
+        match_id = sys.argv[idx + 1]
+
+if match_id:
+    print(f"Testing match ID: {match_id}\n")
+else:
+    # Search all leagues for today/tomorrow matches
+    today = datetime.now().strftime("%Y-%m-%d")
+    tomorrow = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+    matches = []
+
+    print(f"Scanning {len(SEASONS)} leagues for matches {today} to {tomorrow}...\n")
+    for league, sid in SEASONS.items():
+        league_matches = scraper.get_season_matches(sid, today, tomorrow)
+        if league_matches:
+            print(f"  {league}: {len(league_matches)} matches")
+            matches.extend(league_matches)
+
+    if not matches:
+        next_week = (datetime.now() + timedelta(days=14)).strftime("%Y-%m-%d")
+        print(f"\nNo matches today/tomorrow. Trying {today} to {next_week}...")
+        for league, sid in SEASONS.items():
+            league_matches = scraper.get_season_matches(sid, today, next_week)
+            if league_matches:
+                print(f"  {league}: {len(league_matches)} matches")
+                matches.extend(league_matches)
+
+    if not matches:
+        print("No upcoming matches found. Try passing --match-id directly.")
+        sys.exit(0)
+
+    for m in matches:
+        mi = m.get("matchInfo", {})
+        conts = mi.get("contestant", [])
+        home = next((c["name"] for c in conts if c.get("position") == "home"), "?")
+        away = next((c["name"] for c in conts if c.get("position") == "away"), "?")
+        status = m.get("liveData", {}).get("matchDetails", {}).get("matchStatus", "Unknown")
+        dt = mi.get("date", "?")
+        tm = mi.get("time", "")
+        mid = mi.get("id")
+
+        marker = ""
+        if status in ("Playing", "FirstHalf", "SecondHalf", "HalfTime"):
+            marker = " *** LIVE ***"
+        elif status == "Played":
+            marker = " (finished)"
+
+        print(f"  {home} vs {away} | {dt} {tm} | status={status} | id={mid}{marker}")
+
+        # Auto-select a live match, or fall back to most recent played
+        if status in ("Playing", "FirstHalf", "SecondHalf", "HalfTime"):
+            match_id = mid
+            print(f"\n  → Found LIVE match! Testing events...\n")
+            break
+
+    if not match_id:
+        # No live match — try the first played match for a baseline test
+        played = [m for m in matches if m.get("liveData", {}).get("matchDetails", {}).get("matchStatus") == "Played"]
+        if played:
+            match_id = played[-1]["matchInfo"]["id"]
+            desc = played[-1]["matchInfo"].get("description", match_id)
+            print(f"\nNo live match found. Testing most recent played: {desc} ({match_id})\n")
+        else:
+            # Try a fixture (scheduled match) to see what the API returns
+            fixture = [m for m in matches if m.get("liveData", {}).get("matchDetails", {}).get("matchStatus") == "Fixture"]
+            if fixture:
+                match_id = fixture[0]["matchInfo"]["id"]
+                desc = fixture[0]["matchInfo"].get("description", match_id)
+                print(f"\nNo live/played match. Testing fixture: {desc} ({match_id})\n")
+
+if not match_id:
+    print("No match ID to test.")
+    sys.exit(0)
+
+# Test 1: Match events (matchevent endpoint — full event data with x/y)
+print(f"=== Testing matchevent/{match_id} ===")
+event_data = scraper.get_match_events(match_id)
+if event_data:
+    live_data = event_data.get("liveData", {})
+    status = live_data.get("matchDetails", {}).get("matchStatus", "?")
+    print(f"  Status: {status}")
+
+    events = live_data.get("event", [])
+    print(f"  Events: {len(events)}")
+
+    if events:
+        # Show first 5 events
+        print(f"  First 5 events:")
+        for e in events[:5]:
+            etype = e.get("typeId", "?")
+            desc = e.get("type", {}).get("name", "?") if isinstance(e.get("type"), dict) else e.get("type", "?")
+            x = e.get("x", "?")
+            y = e.get("y", "?")
+            period = e.get("periodId", "?")
+            time_min = e.get("timeMin", "?")
+            player = e.get("playerName", e.get("player", {}).get("name", "?") if isinstance(e.get("player"), dict) else "?")
+            print(f"    {desc} | x={x} y={y} | period={period} min={time_min} | player={player}")
+
+        # Count events with x/y
+        with_xy = sum(1 for e in events if e.get("x") is not None and e.get("y") is not None)
+        print(f"\n  Events with x/y coordinates: {with_xy}/{len(events)} ({100*with_xy//max(len(events),1)}%)")
+
+        # Event type distribution
+        types = {}
+        for e in events:
+            t = e.get("type", {}).get("name", "?") if isinstance(e.get("type"), dict) else str(e.get("typeId", "?"))
+            types[t] = types.get(t, 0) + 1
+        print(f"\n  Event types (top 10):")
+        for t, count in sorted(types.items(), key=lambda x: -x[1])[:10]:
+            print(f"    {t}: {count}")
+    else:
+        print("  No events returned — API may not serve events for this match status")
+else:
+    print("  API returned no data (404 or error)")
+
+# Test 2: Match stats (for comparison)
+print(f"\n=== Testing matchstats/{match_id} ===")
+stats_data = scraper.get_match_stats(match_id)
+if stats_data:
+    status = stats_data.get("liveData", {}).get("matchDetails", {}).get("matchStatus", "?")
+    print(f"  Status: {status}")
+    lineup = stats_data.get("liveData", {}).get("lineUp", [])
+    if lineup:
+        total_players = sum(len(t.get("player", [])) for t in lineup)
+        print(f"  Players in lineup: {total_players}")
+    else:
+        print("  No lineup data")
+else:
+    print("  API returned no data")
+
+print("\nDone.")

--- a/scripts/opta/test_live_events.py
+++ b/scripts/opta/test_live_events.py
@@ -18,13 +18,13 @@ scraper = OptaScraper()
 # Season IDs for leagues we want to test (add more as needed)
 SEASONS = {
     "EPL": "51r6ph2woavlbbpk8f29nynf8",
+    "Serie A": "emdmtfr1v8rey2qru3xzfwges",
+    "La Liga": "80zg2v1cuqcfhphn56u4qpyqc",
+    "Bundesliga": "2bchmrj23l9u42d68ntcekob8",
+    "Ligue 1": "dbxs75cag7zyip5re0ppsanmc",
     "AFC CL Two": "bx57cmq1edfq53ckfk791supi",
     "AFC CL Elite": "3qixixbgvsajit71o6mxb7x4a",
     "A-League": "bi1u4m4xssntipznvmocabh39",
-    "La Liga": "eum3wxkqwgz7bhrk5kz7zu5ek",
-    "Serie A": "41cp0wg7b0ck2g85kpwtvdkm2",
-    "Bundesliga": "ajnp97j8msxafqbqyq3sd2s3e",
-    "Ligue 1": "bnh4b93kc4g5s2lv2kbvl3p22",
 }
 
 # Check for --match-id argument

--- a/scripts/rebuild_match_stats.R
+++ b/scripts/rebuild_match_stats.R
@@ -2,12 +2,8 @@
 library(arrow); library(dplyr)
 dir.create("blog", showWarnings = FALSE)
 
-comp_to_code <- c(
-  EPL = "ENG", Championship = "ENG2", La_Liga = "ESP", Ligue_1 = "FRA",
-  Bundesliga = "GER", Serie_A = "ITA", Eredivisie = "NED",
-  Primeira_Liga = "POR", Scottish_Premiership = "SCO", Super_Lig = "TUR",
-  UCL = "UCL", UEL = "UEL", Conference_League = "UECL"
-)
+source("scripts/league_config.R")
+comp_to_code <- BLOG_COMP_TO_CODE
 
 # Use arrow dataset for lazy evaluation — avoids loading 247MB into R memory at once
 ds <- open_dataset("source/opta_player_stats.parquet", format = "parquet")

--- a/scripts/rebuild_match_stats.R
+++ b/scripts/rebuild_match_stats.R
@@ -5,7 +5,8 @@ dir.create("blog", showWarnings = FALSE)
 comp_to_code <- c(
   EPL = "ENG", Championship = "ENG2", La_Liga = "ESP", Ligue_1 = "FRA",
   Bundesliga = "GER", Serie_A = "ITA", Eredivisie = "NED",
-  Primeira_Liga = "POR", Scottish_Premiership = "SCO", Super_Lig = "TUR"
+  Primeira_Liga = "POR", Scottish_Premiership = "SCO", Super_Lig = "TUR",
+  UCL = "UCL", UEL = "UEL", Conference_League = "UECL"
 )
 
 # Use arrow dataset for lazy evaluation — avoids loading 247MB into R memory at once

--- a/scripts/simulate_season.R
+++ b/scripts/simulate_season.R
@@ -42,10 +42,12 @@ leagues <- unique(predictions$league)
 cat("Leagues:", paste(leagues, collapse = ", "), "\n")
 cat("Matches after filtering:", nrow(predictions), "\n\n")
 
-# ── Simulate one season for a league ───────────────────────────────────
+# ── Simulate one season for a league (vectorized) ─────────────────────
 simulate_league <- function(preds, league_standings = NULL, n_sims = N_SIMS) {
   teams <- sort(unique(c(preds$home_team, preds$away_team)))
   n_teams <- length(teams)
+  n_matches <- nrow(preds)
+  team_idx <- setNames(seq_along(teams), teams)
 
   # Build current standings lookup
   cur_pts <- setNames(rep(0L, n_teams), teams)
@@ -63,45 +65,58 @@ simulate_league <- function(preds, league_standings = NULL, n_sims = N_SIMS) {
     }
   }
 
-  # Initialize result arrays (remaining games only — added to current later)
+  # Pre-compute match indices and probabilities as vectors
+  home_idx <- team_idx[preds$home_team]
+  away_idx <- team_idx[preds$away_team]
+  prob_H <- preds$prob_H
+  prob_HD <- preds$prob_H + preds$prob_D
+  gd_match <- preds$pred_home_goals - preds$pred_away_goals  # home perspective
+
+  # Generate all random numbers at once: n_sims x n_matches
+  rand <- matrix(runif(n_sims * n_matches), nrow = n_sims, ncol = n_matches)
+
+  # Classify outcomes: 1=home win, 2=draw, 3=away win
+  # Vectorized across all sims and matches simultaneously
+  is_home_win <- rand < rep(prob_H, each = n_sims)
+  is_draw <- !is_home_win & (rand < rep(prob_HD, each = n_sims))
+  is_away_win <- !is_home_win & !is_draw
+
+  # Initialize accumulators
   sim_points <- matrix(0L, nrow = n_sims, ncol = n_teams)
   sim_gd <- matrix(0, nrow = n_sims, ncol = n_teams)
-  colnames(sim_points) <- teams
-  colnames(sim_gd) <- teams
 
-  for (sim in seq_len(n_sims)) {
-    for (i in seq_len(nrow(preds))) {
-      m <- preds[i, ]
-      r <- runif(1)
-      if (r < m$prob_H) {
-        # Home win
-        sim_points[sim, m$home_team] <- sim_points[sim, m$home_team] + 3L
-        sim_gd[sim, m$home_team] <- sim_gd[sim, m$home_team] + (m$pred_home_goals - m$pred_away_goals)
-        sim_gd[sim, m$away_team] <- sim_gd[sim, m$away_team] - (m$pred_home_goals - m$pred_away_goals)
-      } else if (r < m$prob_H + m$prob_D) {
-        # Draw
-        sim_points[sim, m$home_team] <- sim_points[sim, m$home_team] + 1L
-        sim_points[sim, m$away_team] <- sim_points[sim, m$away_team] + 1L
-      } else {
-        # Away win
-        sim_points[sim, m$away_team] <- sim_points[sim, m$away_team] + 3L
-        sim_gd[sim, m$away_team] <- sim_gd[sim, m$away_team] + (m$pred_away_goals - m$pred_home_goals)
-        sim_gd[sim, m$home_team] <- sim_gd[sim, m$home_team] - (m$pred_away_goals - m$pred_home_goals)
-      }
-    }
+  # Process each match vectorized across all sims
+  for (m in seq_len(n_matches)) {
+    hi <- home_idx[m]
+    ai <- away_idx[m]
+    gd_m <- gd_match[m]
+
+    hw <- is_home_win[, m]
+    dr <- is_draw[, m]
+    aw <- is_away_win[, m]
+
+    # Points
+    sim_points[hw, hi] <- sim_points[hw, hi] + 3L
+    sim_points[dr, hi] <- sim_points[dr, hi] + 1L
+    sim_points[dr, ai] <- sim_points[dr, ai] + 1L
+    sim_points[aw, ai] <- sim_points[aw, ai] + 3L
+
+    # Goal difference
+    sim_gd[hw, hi] <- sim_gd[hw, hi] + gd_m
+    sim_gd[hw, ai] <- sim_gd[hw, ai] - gd_m
+    sim_gd[aw, ai] <- sim_gd[aw, ai] - gd_m
+    sim_gd[aw, hi] <- sim_gd[aw, hi] + gd_m
   }
 
-  # Add current standings to each simulation for ranking
+  # Add current standings for ranking
   total_points <- sweep(sim_points, 2, cur_pts, "+")
   total_gd <- sweep(sim_gd, 2, cur_gd, "+")
 
-  # Compute positions per simulation (using full-season totals)
+  # Compute positions per simulation (vectorized ranking)
   positions <- matrix(0L, nrow = n_sims, ncol = n_teams)
   colnames(positions) <- teams
   for (sim in seq_len(n_sims)) {
-    pts <- total_points[sim, ]
-    gd <- total_gd[sim, ]
-    ord <- order(-pts, -gd)
+    ord <- order(-total_points[sim, ], -total_gd[sim, ])
     positions[sim, ord] <- seq_along(ord)
   }
 
@@ -151,15 +166,19 @@ for (league in leagues) {
     "no standings"
   }
 
+  t0 <- proc.time()["elapsed"]
   cat("Simulating", league, ":", nrow(league_preds), "remaining matches,",
       length(unique(c(league_preds$home_team, league_preds$away_team))), "teams,",
-      standings_label, "\n")
+      standings_label)
 
   result <- simulate_league(league_preds, league_standings, N_SIMS)
   result$league <- league
   result$season <- season %||% ""
   result$matchday <- as.integer(matchdays)
   result$n_sims <- N_SIMS
+
+  elapsed <- round(proc.time()["elapsed"] - t0, 1)
+  cat(sprintf(" [%.1fs]\n", elapsed))
 
   all_results[[league]] <- result
 }

--- a/scripts/simulate_season.R
+++ b/scripts/simulate_season.R
@@ -1,15 +1,12 @@
 # simulate_season.R — Monte Carlo season simulations for football leagues
-# Generates football/simulations.parquet for the inthegame-blog ladder page.
+# Generates football/simulations.parquet for the inthegame-blog leagues page.
 #
-# Requires: predictions.parquet (from build_blog_data.R) with remaining fixtures
-#   and team-level strength estimates from Panna ratings.
+# Requires:
+#   - blog/predictions.parquet: remaining fixtures with Panna probabilities
+#   - blog/season_standings.parquet: current standings (points, GD, games played)
 #
 # Usage: Rscript scripts/simulate_season.R
 # Output: blog/simulations.parquet
-#
-# TODO: Hook into Panna model's team strength estimates.
-#       Currently uses a placeholder that needs replacing with actual
-#       panna::predict_match() or equivalent.
 
 library(arrow)
 library(dplyr)
@@ -26,10 +23,15 @@ if (!file.exists(pred_file)) stop("predictions.parquet not found. Run build_blog
 predictions <- read_parquet(pred_file)
 cat("Loaded", nrow(predictions), "match predictions\n")
 
-# ── Load fixture results for current standings ──────────────────────────
-# The fixtures JSON has actual results for played matches.
-# For now, we compute current standings from predictions that have actual results.
-# TODO: Load fixtures.json or use a separate results source.
+# ── Load current standings ────────────────────────────────────────────
+standings_file <- "blog/season_standings.parquet"
+if (file.exists(standings_file)) {
+  standings <- read_parquet(standings_file)
+  cat("Loaded standings for", nrow(standings), "teams\n")
+} else {
+  warning("season_standings.parquet not found — probabilities will be based on remaining games only.")
+  standings <- NULL
+}
 
 # ── Filter to domestic leagues only (cups have TBD matchups) ──────────
 league_codes <- c("ENG", "ENG2", "ESP", "FRA", "GER", "ITA", "NED", "POR", "SCO", "TUR")
@@ -41,40 +43,59 @@ cat("Leagues:", paste(leagues, collapse = ", "), "\n")
 cat("Matches after filtering:", nrow(predictions), "\n\n")
 
 # ── Simulate one season for a league ───────────────────────────────────
-simulate_league <- function(preds, n_sims = N_SIMS) {
+simulate_league <- function(preds, league_standings = NULL, n_sims = N_SIMS) {
   teams <- sort(unique(c(preds$home_team, preds$away_team)))
   n_teams <- length(teams)
 
-  # Initialize result arrays
-  total_points <- matrix(0L, nrow = n_sims, ncol = n_teams)
-  total_gd <- matrix(0, nrow = n_sims, ncol = n_teams)
-  colnames(total_points) <- teams
-  colnames(total_gd) <- teams
+  # Build current standings lookup
+  cur_pts <- setNames(rep(0L, n_teams), teams)
+  cur_gd <- setNames(rep(0, n_teams), teams)
+  cur_gp <- setNames(rep(0L, n_teams), teams)
 
-  for (sim in seq_len(n_sims)) {
-    for (i in seq_len(nrow(preds))) {
-      m <- preds[i, ]
-      # Sample match result from Panna probabilities
-      r <- runif(1)
-      if (r < m$prob_H) {
-        # Home win
-        total_points[sim, m$home_team] <- total_points[sim, m$home_team] + 3L
-        total_gd[sim, m$home_team] <- total_gd[sim, m$home_team] + (m$pred_home_goals - m$pred_away_goals)
-        total_gd[sim, m$away_team] <- total_gd[sim, m$away_team] - (m$pred_home_goals - m$pred_away_goals)
-      } else if (r < m$prob_H + m$prob_D) {
-        # Draw
-        total_points[sim, m$home_team] <- total_points[sim, m$home_team] + 1L
-        total_points[sim, m$away_team] <- total_points[sim, m$away_team] + 1L
-      } else {
-        # Away win
-        total_points[sim, m$away_team] <- total_points[sim, m$away_team] + 3L
-        total_gd[sim, m$away_team] <- total_gd[sim, m$away_team] + (m$pred_away_goals - m$pred_home_goals)
-        total_gd[sim, m$home_team] <- total_gd[sim, m$home_team] - (m$pred_away_goals - m$pred_home_goals)
+  if (!is.null(league_standings)) {
+    for (i in seq_len(nrow(league_standings))) {
+      tm <- league_standings$team[i]
+      if (tm %in% teams) {
+        cur_pts[tm] <- league_standings$points[i]
+        cur_gd[tm] <- league_standings$gd[i]
+        cur_gp[tm] <- league_standings$games_played[i]
       }
     }
   }
 
-  # Compute positions per simulation
+  # Initialize result arrays (remaining games only — added to current later)
+  sim_points <- matrix(0L, nrow = n_sims, ncol = n_teams)
+  sim_gd <- matrix(0, nrow = n_sims, ncol = n_teams)
+  colnames(sim_points) <- teams
+  colnames(sim_gd) <- teams
+
+  for (sim in seq_len(n_sims)) {
+    for (i in seq_len(nrow(preds))) {
+      m <- preds[i, ]
+      r <- runif(1)
+      if (r < m$prob_H) {
+        # Home win
+        sim_points[sim, m$home_team] <- sim_points[sim, m$home_team] + 3L
+        sim_gd[sim, m$home_team] <- sim_gd[sim, m$home_team] + (m$pred_home_goals - m$pred_away_goals)
+        sim_gd[sim, m$away_team] <- sim_gd[sim, m$away_team] - (m$pred_home_goals - m$pred_away_goals)
+      } else if (r < m$prob_H + m$prob_D) {
+        # Draw
+        sim_points[sim, m$home_team] <- sim_points[sim, m$home_team] + 1L
+        sim_points[sim, m$away_team] <- sim_points[sim, m$away_team] + 1L
+      } else {
+        # Away win
+        sim_points[sim, m$away_team] <- sim_points[sim, m$away_team] + 3L
+        sim_gd[sim, m$away_team] <- sim_gd[sim, m$away_team] + (m$pred_away_goals - m$pred_home_goals)
+        sim_gd[sim, m$home_team] <- sim_gd[sim, m$home_team] - (m$pred_away_goals - m$pred_home_goals)
+      }
+    }
+  }
+
+  # Add current standings to each simulation for ranking
+  total_points <- sweep(sim_points, 2, cur_pts, "+")
+  total_gd <- sweep(sim_gd, 2, cur_gd, "+")
+
+  # Compute positions per simulation (using full-season totals)
   positions <- matrix(0L, nrow = n_sims, ncol = n_teams)
   colnames(positions) <- teams
   for (sim in seq_len(n_sims)) {
@@ -87,13 +108,16 @@ simulate_league <- function(preds, n_sims = N_SIMS) {
   # Aggregate results
   results <- tibble(
     team = teams,
-    avg_points = round(colMeans(total_points), 1),
-    avg_gd = round(colMeans(total_gd), 1),
+    avg_points = round(colMeans(sim_points), 1),
+    avg_gd = round(colMeans(sim_gd), 1),
     avg_position = round(colMeans(positions), 1),
     title_pct = round(colMeans(positions == 1), 4),
     top_4_pct = round(colMeans(positions <= 4), 4),
     top_half_pct = round(colMeans(positions <= ceiling(n_teams / 2)), 4),
-    bottom_3_pct = round(colMeans(positions > n_teams - 3), 4)
+    bottom_3_pct = round(colMeans(positions > n_teams - 3), 4),
+    current_points = as.integer(cur_pts[teams]),
+    current_gd = as.integer(cur_gd[teams]),
+    games_played = as.integer(cur_gp[teams])
   )
 
   # Position distribution (pos_1_pct through pos_N_pct)
@@ -110,26 +134,32 @@ all_results <- list()
 for (league in leagues) {
   league_preds <- predictions |> filter(league == !!league)
 
+  # Get standings for this league
+  league_standings <- NULL
+  if (!is.null(standings)) {
+    league_standings <- standings |> filter(league == !!league)
+    if (nrow(league_standings) == 0) league_standings <- NULL
+  }
+
   # Determine season and current matchday
   season <- unique(league_preds$season)[1]
-  # Matchday approximation: count distinct dates
   matchdays <- length(unique(league_preds$match_date))
 
-  cat("Simulating", league, ":", nrow(league_preds), "remaining matches,",
-      length(unique(c(league_preds$home_team, league_preds$away_team))), "teams\n")
+  standings_label <- if (!is.null(league_standings)) {
+    sprintf("%d teams with standings", nrow(league_standings))
+  } else {
+    "no standings"
+  }
 
-  result <- simulate_league(league_preds, N_SIMS)
+  cat("Simulating", league, ":", nrow(league_preds), "remaining matches,",
+      length(unique(c(league_preds$home_team, league_preds$away_team))), "teams,",
+      standings_label, "\n")
+
+  result <- simulate_league(league_preds, league_standings, N_SIMS)
   result$league <- league
   result$season <- season %||% ""
   result$matchday <- as.integer(matchdays)
   result$n_sims <- N_SIMS
-
-  # TODO: Add current standings (games_played, current_points, current_gd)
-  # These come from fixture results for already-played matches.
-  # For now, set to NA — the front-end handles missing values gracefully.
-  result$games_played <- NA_integer_
-  result$current_points <- NA_integer_
-  result$current_gd <- NA_integer_
 
   all_results[[league]] <- result
 }

--- a/scripts/simulate_season.R
+++ b/scripts/simulate_season.R
@@ -131,7 +131,7 @@ simulate_league <- function(preds, league_standings = NULL, n_sims = N_SIMS) {
     top_half_pct = round(colMeans(positions <= ceiling(n_teams / 2)), 4),
     bottom_3_pct = round(colMeans(positions > n_teams - 3), 4),
     current_points = as.integer(cur_pts[teams]),
-    current_gd = as.integer(cur_gd[teams]),
+    current_gd = round(cur_gd[teams]),
     games_played = as.integer(cur_gp[teams])
   )
 


### PR DESCRIPTION
## Summary
- Opta scrapes UEFA club competitions daily but the build step filtered them out
- Added UCL, UEL, Conference League to match-shots, match-stats, chains, league-xg, and predictions xG enrichment
- Will produce new parquets: `match-stats-UCL/UEL/UECL.parquet`, `chains-UCL/UEL/UECL.parquet`

## Test plan
- [ ] Merge and trigger "Build blog data" workflow manually
- [ ] Verify new parquets appear on R2 (`football/match-stats-UCL.parquet`, etc.)
- [ ] Check a UCL match page shows shot map, xG timeline, and match stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)