### PR TITLE
feat: --seasons scrape dispatch + blog data new columns

### DIFF
--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -54,7 +54,10 @@ if (file.exists(gl_path)) {
   # Only pull columns that don't already exist in xrapm/spm (to avoid collisions).
   # panna/offense/defense/spm_overall/panna_percentile are excluded — those come from xrapm+spm.
   extra_cols <- intersect(
-    c("epv_total", "epv_passing", "epv_shooting", "epv_dribbling", "epv_defending",
+    c("epv_total",
+      "epv_total_adj", "epv_offensive_adj", "epv_defensive_adj", "opp_adj",
+      "epv_passing", "epv_shooting", "epv_dribbling",
+      "epv_aerial", "epv_keeping", "epv_defending",
       "wpa_total", "wpa_as_actor", "wpa_as_receiver",
       "psv", "osv", "dsv", "panna_value_p90"),
     names(game_logs)
@@ -139,7 +142,10 @@ panna_ratings <- enriched |>
     panna_rank_position, panna_percentile_position,
     offense_percentile_position, defense_percentile_position,
     any_of(c(
-      "epv_total", "epv_passing", "epv_shooting", "epv_dribbling", "epv_defending",
+      "epv_total",
+      "epv_total_adj", "epv_offensive_adj", "epv_defensive_adj", "opp_adj",
+      "epv_passing", "epv_shooting", "epv_dribbling",
+      "epv_aerial", "epv_keeping", "epv_defending",
       "wpa_total", "wpa_as_actor", "wpa_as_receiver",
       "psv", "osv", "dsv", "panna_value_p90"
     ))


### PR DESCRIPTION
## Summary

Two small but high-leverage changes:
1. `workflow_dispatch` on `daily-opta-scrape.yml` now accepts a `seasons` input, enabling targeted tournament scrapes (unblocks missing WC 2022 Qatar + EURO 2020 in the scrape config but not in the consolidated parquets).
2. `build_blog_data.R` pipes through the new adjusted EPV + split component columns added in panna today (epv_total_adj, epv_offensive_adj, epv_defensive_adj, opp_adj, epv_aerial, epv_keeping). Uses `any_of()` so it works gracefully against older game_logs parquets without the new schema.

## What's in this PR

**Workflow: `seasons` input**
- Optional string input; falls through to `--recent N` path when absent → daily cron behavior unchanged.
- Quoting handled explicitly for tournament names with spaces (`"2022 Qatar"`, `"2020"`).
- One season per dispatch; run multiple times for multiple tournaments.

**Blog data builder**
- Extends `extra_cols` and final-select `any_of(...)` to include the 6 new columns from game_logs_*.parquet.

## Context — Football Value tab

Memory flagged the R2 Football Value tab as empty (12 enrichment cols missing + null league/position). Verified 2026-04-21: **already resolved** via the 2026-04-18 FBref archival (which let Opta's `seasonal_xrapm.parquet` become the canonical source, producing correctly-matched hashed player_ids). Current R2 parquet: 4,883 rows × 27 cols, league 99.98% non-null, position 99.5% non-null, all 12 enrichment cols populated.

New columns added by this PR will light up after: (a) this PR merges, (b) panna predictions-pipeline dispatches next Wednesday (or manually), (c) repository_dispatch triggers `build-blog-data.yml`.

## Test plan

- [x] Schema-back-compat: `any_of()` ensures the select doesn't fail if game_logs lacks new columns.
- [x] Workflow dry-run via YAML parse — input schema valid.
- [ ] Post-merge: manually dispatch scrape twice (WC 2022 Qatar, EURO 2020) to fill the scraping gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)