### PR TITLE
fix(scraper): date windows for non-standard tournaments (WC 2022 Qatar, EURO 2020)

### DIFF
--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -54,7 +54,10 @@ if (file.exists(gl_path)) {
   # Only pull columns that don't already exist in xrapm/spm (to avoid collisions).
   # panna/offense/defense/spm_overall/panna_percentile are excluded — those come from xrapm+spm.
   extra_cols <- intersect(
-    c("epv_total", "epv_passing", "epv_shooting", "epv_dribbling", "epv_defending",
+    c("epv_total",
+      "epv_total_adj", "epv_offensive_adj", "epv_defensive_adj", "opp_adj",
+      "epv_passing", "epv_shooting", "epv_dribbling",
+      "epv_aerial", "epv_keeping", "epv_defending",
       "wpa_total", "wpa_as_actor", "wpa_as_receiver",
       "psv", "osv", "dsv", "panna_value_p90"),
     names(game_logs)
@@ -139,7 +142,10 @@ panna_ratings <- enriched |>
     panna_rank_position, panna_percentile_position,
     offense_percentile_position, defense_percentile_position,
     any_of(c(
-      "epv_total", "epv_passing", "epv_shooting", "epv_dribbling", "epv_defending",
+      "epv_total",
+      "epv_total_adj", "epv_offensive_adj", "epv_defensive_adj", "opp_adj",
+      "epv_passing", "epv_shooting", "epv_dribbling",
+      "epv_aerial", "epv_keeping", "epv_defending",
       "wpa_total", "wpa_as_actor", "wpa_as_receiver",
       "psv", "osv", "dsv", "panna_value_p90"
     ))

--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -208,12 +208,37 @@ def is_future_season(season_name: str) -> bool:
         return year > current_year
 
 
+# Tournaments that don't follow the "name year IS the year it was played in"
+# convention — COVID delays, winter World Cups, etc. The standard logic of
+# "year - 1 → year" misses their actual fixture windows entirely, so the scrape
+# returns "no new matches" even though the season exists in seasons.json.
+TOURNAMENT_DATE_EXCEPTIONS = {
+    # Winter World Cup — played Nov 20 – Dec 18, 2022. Not in the default
+    # Aug 2021 – Jul 2022 window.
+    "2022 Qatar": [
+        ("2022-11-01", "2022-12-31"),
+    ],
+    # EURO 2020 — COVID-delayed to Jun 11 – Jul 11, 2021. Labelled "2020" in
+    # Opta (no host country) because it was pan-European.
+    "2020": [
+        ("2021-06-01", "2021-07-31"),
+    ],
+}
+
+
 def get_season_date_range(season_name: str) -> tuple:
     """Get start and end dates for a season (Aug-May typical)
 
-    Handles both league seasons (2024-2025) and tournament seasons (2025 Morocco, 2024/2025)
+    Handles both league seasons (2024-2025) and tournament seasons (2025 Morocco, 2024/2025).
+    Returns an explicit exception table for tournaments whose actual play window
+    doesn't match the naming convention (e.g. Qatar 2022 played winter, EURO 2020
+    played in 2021).
     """
     import re
+
+    # Explicit exceptions override the name-based inference.
+    if season_name in TOURNAMENT_DATE_EXCEPTIONS:
+        return TOURNAMENT_DATE_EXCEPTIONS[season_name]
 
     # Extract year(s) from season name
     years = re.findall(r'20\d\d', season_name)


### PR DESCRIPTION
## Problem

Dispatching the scrape today for WC 2022 Qatar and EURO 2020 returned "no new matches" even though both seasons are configured in `seasons.json`. Root cause: `get_season_date_range()` assumes a tournament named "YYYY X" was played in summer YYYY and generates windows spanning Aug (year-1) → Jul (year). Two real-world exceptions fall outside this window:

- **WC 2022 Qatar**: played **Nov 20 – Dec 18, 2022** (winter World Cup due to heat). Default window Aug 2021 – Jul 2022 misses it entirely.
- **EURO 2020**: COVID-delayed to **Jun 11 – Jul 11, 2021**. Opta labels it just "2020" (no host country — pan-European). Default window Aug 2019 – Jul 2020 misses it entirely.

The scrape calls the Opta fixtures API in each date window, finds no matches in any of them, reports success with zero new data, and the consolidated parquet stays unchanged.

## Fix

Add a `TOURNAMENT_DATE_EXCEPTIONS` dict that short-circuits `get_season_date_range()` for known-offbeat tournaments. Extend it for any future exceptions (e.g. if WC 2026 gets rescheduled).

```python
TOURNAMENT_DATE_EXCEPTIONS = {
    "2022 Qatar": [("2022-11-01", "2022-12-31")],
    "2020":       [("2021-06-01", "2021-07-31")],
}
```

## Test plan

- [x] Verified dispatch on main branch today returned "No new parquet files, but scraper ran successfully (no new matches)" for both WC 2022 and EURO 2020 — confirmed the bug.
- [ ] After merge: redispatch both seasons. Expected: scraper fetches the correct nov-dec 2022 / jun-jul 2021 windows, finds matches, writes parquets under `match_events/World_Cup/2022 Qatar.parquet` and `match_events/UEFA_Euros/2020.parquet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)