### PR TITLE
fix(scrape): silent-empty detection + concurrent-run race fix

### DIFF
--- a/.github/workflows/daily-opta-scrape.yml
+++ b/.github/workflows/daily-opta-scrape.yml
@@ -122,6 +122,8 @@ jobs:
         fi
 
     - name: Build consolidated parquet files
+      env:
+        INPUT_SEASONS: ${{ github.event.inputs.seasons }}
       run: |
         cd data
         # Count only raw per-league season files (not consolidated opta_*.parquet at the root)
@@ -130,6 +132,21 @@ jobs:
         if [ "$PARQUET_COUNT" -eq 0 ]; then
           # Distinguish "no new data" from "scraper crashed"
           if [ -f "../scripts/opta/data/scrape_summary.json" ]; then
+            # Silent-empty guard: if the user dispatched with --seasons (targeted
+            # a specific tournament/season) and zero new matches came back,
+            # fail loudly rather than exit 0. A silent-success here hides real
+            # bugs like the TOURNAMENT_DATE_EXCEPTIONS miss that wasted 20 min
+            # thinking WC 2022 Qatar had landed when the wrong date window had
+            # silently returned nothing.
+            if [ -n "$INPUT_SEASONS" ]; then
+              echo "::error::--seasons='$INPUT_SEASONS' dispatched but scraper returned zero new matches."
+              echo "Likely causes:"
+              echo "  1. Wrong date window for this tournament — add to TOURNAMENT_DATE_EXCEPTIONS in scrape_opta.py"
+              echo "  2. All matches already in the manifest (try --force)"
+              echo "  3. Season name mismatch with seasons.json"
+              echo "  4. Upstream Opta API issue"
+              exit 1
+            fi
             echo "No new parquet files, but scraper ran successfully (no new matches)"
             exit 0
           else
@@ -137,6 +154,20 @@ jobs:
             exit 1
           fi
         fi
+
+        # Snapshot existing event-consolidated mtimes BEFORE consolidate so
+        # the upload step can later skip unchanged files (prevents the
+        # concurrent-scrape race where one run overwrites another's uploads
+        # of leagues it didn't touch).
+        mkdir -p /tmp/scrape-state
+        if [ -d "opta/events_consolidated" ]; then
+          find opta/events_consolidated -name "events_*.parquet" \
+            -printf "%f %T@\n" 2>/dev/null | sort > /tmp/scrape-state/pre_mtimes.txt
+          echo "Snapshotted $(wc -l < /tmp/scrape-state/pre_mtimes.txt) existing events parquet mtimes"
+        else
+          touch /tmp/scrape-state/pre_mtimes.txt
+        fi
+
         python ../scripts/opta/consolidate_opta.py
 
     - name: Setup R for xG enrichment
@@ -209,18 +240,38 @@ jobs:
           fi
         fi
 
-        # Upload per-league events files
+        # Upload per-league events files — but only those the consolidate
+        # step actually modified. This prevents the concurrent-scrape race
+        # condition where run A (scrapes WC) and run B (scrapes EURO) both
+        # upload the full set of events_*.parquet files at the end, and
+        # whichever finishes second silently overwrites the other's
+        # modifications for leagues it didn't touch. Compare pre-consolidate
+        # mtimes (snapshotted in the Build step) against current mtimes.
         if [ -d "opta/events_consolidated" ]; then
+          PRE_MTIMES=/tmp/scrape-state/pre_mtimes.txt
+          uploaded_count=0
+          skipped_count=0
           for f in opta/events_consolidated/events_*.parquet; do
             [ -f "$f" ] || continue
-            if gh release upload opta-latest "$f" --clobber; then
-              echo "Uploaded $(basename $f)"
+            base=$(basename "$f")
+            post_mtime=$(stat --printf "%Y" "$f")
+            pre_mtime=""
+            if [ -f "$PRE_MTIMES" ]; then
+              pre_mtime=$(awk -v name="$base" '$1 == name {printf "%d", $2}' "$PRE_MTIMES")
+            fi
+            if [ -z "$pre_mtime" ] || [ "$pre_mtime" != "$post_mtime" ]; then
+              if gh release upload opta-latest "$f" --clobber; then
+                echo "Uploaded $base (modified this run)"
+                uploaded_count=$((uploaded_count + 1))
+              else
+                echo "ERROR: Failed to upload $base"
+                upload_errors=$((upload_errors + 1))
+              fi
             else
-              echo "ERROR: Failed to upload $(basename $f)"
-              upload_errors=$((upload_errors + 1))
+              skipped_count=$((skipped_count + 1))
             fi
           done
-          echo "Uploaded $(ls opta/events_consolidated/events_*.parquet 2>/dev/null | wc -l) events files"
+          echo "Events files: $uploaded_count uploaded (modified), $skipped_count skipped (unchanged)"
         fi
 
         if [ "$upload_errors" -gt 0 ]; then

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -54,7 +54,10 @@ if (file.exists(gl_path)) {
   # Only pull columns that don't already exist in xrapm/spm (to avoid collisions).
   # panna/offense/defense/spm_overall/panna_percentile are excluded — those come from xrapm+spm.
   extra_cols <- intersect(
-    c("epv_total", "epv_passing", "epv_shooting", "epv_dribbling", "epv_defending",
+    c("epv_total",
+      "epv_total_adj", "epv_offensive_adj", "epv_defensive_adj", "opp_adj",
+      "epv_passing", "epv_shooting", "epv_dribbling",
+      "epv_aerial", "epv_keeping", "epv_defending",
       "wpa_total", "wpa_as_actor", "wpa_as_receiver",
       "psv", "osv", "dsv", "panna_value_p90"),
     names(game_logs)
@@ -139,7 +142,10 @@ panna_ratings <- enriched |>
     panna_rank_position, panna_percentile_position,
     offense_percentile_position, defense_percentile_position,
     any_of(c(
-      "epv_total", "epv_passing", "epv_shooting", "epv_dribbling", "epv_defending",
+      "epv_total",
+      "epv_total_adj", "epv_offensive_adj", "epv_defensive_adj", "opp_adj",
+      "epv_passing", "epv_shooting", "epv_dribbling",
+      "epv_aerial", "epv_keeping", "epv_defending",
       "wpa_total", "wpa_as_actor", "wpa_as_receiver",
       "psv", "osv", "dsv", "panna_value_p90"
     ))

--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -208,12 +208,37 @@ def is_future_season(season_name: str) -> bool:
         return year > current_year
 
 
+# Tournaments that don't follow the "name year IS the year it was played in"
+# convention — COVID delays, winter World Cups, etc. The standard logic of
+# "year - 1 → year" misses their actual fixture windows entirely, so the scrape
+# returns "no new matches" even though the season exists in seasons.json.
+TOURNAMENT_DATE_EXCEPTIONS = {
+    # Winter World Cup — played Nov 20 – Dec 18, 2022. Not in the default
+    # Aug 2021 – Jul 2022 window.
+    "2022 Qatar": [
+        ("2022-11-01", "2022-12-31"),
+    ],
+    # EURO 2020 — COVID-delayed to Jun 11 – Jul 11, 2021. Labelled "2020" in
+    # Opta (no host country) because it was pan-European.
+    "2020": [
+        ("2021-06-01", "2021-07-31"),
+    ],
+}
+
+
 def get_season_date_range(season_name: str) -> tuple:
     """Get start and end dates for a season (Aug-May typical)
 
-    Handles both league seasons (2024-2025) and tournament seasons (2025 Morocco, 2024/2025)
+    Handles both league seasons (2024-2025) and tournament seasons (2025 Morocco, 2024/2025).
+    Returns an explicit exception table for tournaments whose actual play window
+    doesn't match the naming convention (e.g. Qatar 2022 played winter, EURO 2020
+    played in 2021).
     """
     import re
+
+    # Explicit exceptions override the name-based inference.
+    if season_name in TOURNAMENT_DATE_EXCEPTIONS:
+        return TOURNAMENT_DATE_EXCEPTIONS[season_name]
 
     # Extract year(s) from season name
     years = re.findall(r'20\d\d', season_name)


### PR DESCRIPTION
## Summary

Two scraper-workflow hardening fixes for silent-failure modes uncovered during today's WC 2022 / EURO 2020 backfill. Both cost real debugging time — they look like "success" from outside but silently either swallow no-data dispatches (#5) or overwrite other runs' uploads (#4).

## Fix 1 — Silent-empty scrape detection

Before: if a \`--seasons\`-targeted dispatch fetched zero matches (e.g. because of wrong date window), the workflow would exit 0 with "No new parquet files, but scraper ran successfully."

After: if \`INPUT_SEASONS\` is set AND zero new parquet files were written, fail the run with a diagnostic listing likely causes:
- Wrong date window — suggests adding to \`TOURNAMENT_DATE_EXCEPTIONS\` in \`scrape_opta.py\`
- All matches already in the manifest (needs \`--force\`)
- Season name mismatch with \`seasons.json\`
- Upstream API issue

Daily cron behavior unchanged (\`INPUT_SEASONS\` is empty on cron).

## Fix 2 — Upload only events files this run actually modified

Concurrent-scrape race: two dispatches (WC + EURO) both downloaded the full \`events_*.parquet\` set at start, both ran consolidate, both uploaded the full set at end. Whichever ran second silently overwrote the first's changes for leagues it didn't touch.

Fix: snapshot event-consolidated mtimes BEFORE consolidate. In the upload step, compare post-consolidate mtimes against the snapshot — only upload files that changed or are new.

**Scope**: only applies to \`events_consolidated/events_*.parquet\`. The table-level \`opta_*.parquet\` files (shots, stats, etc.) still upload unconditionally because consolidate rewrites them every run.

## Test plan

- [x] Visual inspection of bash logic (mtime snapshot → compare → skip-if-unchanged)
- [ ] Post-merge: dispatch a no-op scrape (e.g. \`--seasons 'not-a-real-season'\`) and confirm the guard fires with an error
- [ ] Post-merge: dispatch a targeted scrape for a league that's already current — confirm upload count reports "N skipped (unchanged)" in logs
- [ ] Post-merge: dispatch two concurrent scrapes for different leagues — confirm neither overwrites the other's changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)