### PR TITLE
fix(scrape): skip future-dated season windows

### DIFF
--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -474,6 +474,7 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
             print(msg)
 
     date_ranges = get_season_date_range(season_name)
+    today_iso = datetime.now().date().isoformat()
 
     # Collectors for all data types
     all_player_stats = []
@@ -488,6 +489,9 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
     all_fixture_records = []
 
     for start_date, end_date in date_ranges:
+        if start_date > today_iso:
+            print(f"\nSkipping future window {start_date} to {end_date} (start > {today_iso})")
+            continue
         print(f"\nFetching {start_date} to {end_date}...")
 
         matches = scraper.get_season_matches(season_id, start_date, end_date)


### PR DESCRIPTION
## Summary
- \`get_season_date_range\` produces 6 fixed 2-month windows per season (Aug-Sep through Jun-Jul of season-end year). For the active 2025-2026 season the final window is \`2026-06-01..2026-07-31\` — currently in the future.
- Opta's API returns 404 for future-dated windows; \`_fetch\` converts that to \`None\`; the pagination guard added in #38 raises \`RuntimeError: get_season_matches: _fetch returned None at page 1 ... Refusing to return a potentially truncated list.\`
- Daily scrape has been red since 2026-04-23 as a result. Health check #5 in ops repo flags this daily.
- Fix: filter date ranges whose \`start_date\` is after today before calling \`get_season_matches\`. Past windows behave unchanged.

## Knock-on
- Recovers \`pannadata/Daily Opta Scrape\`.
- Once one successful run completes, \`enrich_shots_xg.R\` re-uploads enriched \`opta_shot_events.parquet\` to \`opta-latest\`. That should also unblock \`panna/Opta RAPM/SPM Pipeline\` (currently 100% failing because every splint sees zero xG from the un-enriched file).

## Test plan
- [ ] Run \`Daily Opta Scrape\` via \`workflow_dispatch\` after merge — confirm "Skipping future window 2026-06-01..." log line appears for current-season last window
- [ ] Other windows scrape normally, no regression
- [ ] \`opta-latest\` release \`opta_shot_events.parquet\` updates with mean xG > 0 (re-enrichment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)