### PR TITLE
fix(scrape): hoist datetime import to module scope (UnboundLocalError)

### DIFF
--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -31,7 +31,7 @@ import logging
 import shutil
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 from opta_scraper import OptaScraper, MatchEvent, ShotEvent, PlayerLineup, AllMatchEvent
 from dataclasses import asdict
 import pandas as pd
@@ -591,7 +591,6 @@ def scrape_season(scraper: OptaScraper, competition: str, season_name: str,
             # Add manifest record for this match
             # Don't mark as event_unavailable if match is recent (< 7 days old)
             # Events may become available after a few days
-            from datetime import datetime, timedelta
             match_dt = datetime.fromisoformat(match_date.replace('Z', '+00:00'))
             is_recent = (datetime.now(match_dt.tzinfo) - match_dt) < timedelta(days=7)
 


### PR DESCRIPTION
## Summary
- Regression introduced by PR #40. The new \`today_iso = datetime.now().date().isoformat()\` at line 477 of \`scrape_opta.py\` was inside \`scrape_season()\`, which already had a local \`from datetime import datetime, timedelta\` at line 594.
- Python's function-scoping rule: any name assigned (including imports) inside a function is treated as local throughout the entire function, regardless of statement order. So \`datetime\` at line 477 was already a local reference — but unbound at runtime since the local binding only happens at line 594.
- Result: \`UnboundLocalError: cannot access local variable 'datetime' where it is not associated with a value\` immediately at the start of every season scrape. Confirmed in run 24955820766 (post-#40 manual trigger).

## Fix
- Lift the local \`from datetime import datetime, timedelta\` to module scope (line 34 already imports \`datetime\`; just adds \`timedelta\`).
- Removes the redundant in-function import. No behavior change.

## Why this got through review
- pannadata has no test suite. The pure-Python scoping bug is invisible to syntax checking and only manifests at runtime. PR #40 review noted "no test added" as a non-blocking suggestion — this issue would have been caught by even a trivial smoke test that imports and calls \`scrape_season\` with mock inputs.

## Test plan
- [ ] \`python -c "import ast; ast.parse(open('scripts/opta/scrape_opta.py').read())"\` returns clean (verified locally)
- [ ] Re-run \`Daily Opta Scrape\` via \`workflow_dispatch\` after merge — expect "Skipping future window 2026-06-01 to 2026-07-31" log line and successful scrape of past windows
- [ ] \`opta-latest\` release \`opta_shot_events.parquet\` mtime updates and mean(xg_value) > 0 after re-enrichment

🤖 Generated with [Claude Code](https://claude.com/claude-code)