### PR TITLE
fix(scrape): add World Cup 2026 to tournament date exceptions

### DIFF
--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -357,6 +357,12 @@ TOURNAMENT_DATE_EXCEPTIONS = {
     "2020": [
         ("2021-06-01", "2021-07-31"),
     ],
+    # World Cup 2026 — played Jun 11 – Jul 19, 2026 across USA/Canada/Mexico.
+    # Default Aug 2025 – Jul 2026 windowing tries pre-tournament months that
+    # have no data and Opta returns 404, tripping the strict pagination guard.
+    "2026 Canada-Mexico-USA": [
+        ("2026-06-01", "2026-07-31"),
+    ],
 }
 
 


### PR DESCRIPTION
## Summary
After PR #40 (future-window skip) and #41 (datetime hoist) landed, the manual scrape got past Ligue_1 2025-2026 successfully but failed at \`World_Cup 2026 Canada-Mexico-USA\` (Opta season ID \`873cbl9cd9butm4air0mugxzo\`):
\`\`\`
RuntimeError: get_season_matches: _fetch returned None at page 1 for season
873cbl9cd9butm4air0mugxzo 2025-08-01..2025-09-30. Refusing to return a
potentially truncated list.
\`\`\`

## Root cause
\`is_future_season("2026 Canada-Mexico-USA")\` (line 308) uses a strict \`year > current_year\` check. WC 2026 has \`year == current_year\` (both 2026), so it slips through the future-season filter at line 810. Default tournament windowing (year_start = year-1, year_end = year) generates Aug 2025 – Jul 2026 windows — and the Aug-Sep 2025 window is empty (tournament hasn't been scheduled there), so Opta 404s and the strict pagination guard from #38 raises.

## Fix
Add \`"2026 Canada-Mexico-USA"\` to \`TOURNAMENT_DATE_EXCEPTIONS\` (line 349) pointing to the actual tournament dates (Jun 11 – Jul 19 2026, padded to Jun 1 – Jul 31). Combined with #40's future-window skip:
- Today (2026-04-26): exception → 1 window (2026-06-01..2026-07-31) → start > today → skipped → no fetch → no error
- After 2026-06-01: window starts past-or-today → fetch proceeds normally

Same pattern as the existing \`"2022 Qatar"\` (winter WC) and \`"2020"\` (COVID-delayed Euro) exceptions.

## Why is_future_season wasn't fixed instead
Could improve \`is_future_season\` to consult \`TOURNAMENT_DATE_EXCEPTIONS\` and check if the first window's start date is after today — but the exception entry alone fully resolves WC 2026 via the existing future-window skip path. A more general fix is reasonable as a follow-up but isn't urgent (Olympics, future Euros etc. would similarly need exceptions or an enhanced is_future_season).

## Test plan
- [ ] Re-run \`Daily Opta Scrape\` via \`workflow_dispatch\` after merge
- [ ] Expect "Skipping future window 2026-06-01 to 2026-07-31" log line for \`World_Cup 2026 Canada-Mexico-USA\`
- [ ] Scrape proceeds past WC 2026 to remaining seasons without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)