### PR TITLE
Ship historical per-season game-logs to R2 (+ rebuild_events Phase 1)

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -49,12 +49,39 @@ jobs:
             echo "::warning::season_standings.parquet not available — simulations will lack current standings"
           fi
 
-          # Game logs (per-match player value metrics — optional, pass through to R2)
+          # Game logs (per-match player value metrics — optional, pass through to R2).
+          #
+          # Two shapes ship to R2:
+          #   football/game-logs.parquet          → current-season alias, the
+          #     fast default the blog loads on EVERY player-stats page view.
+          #   football/game-logs-<season>.parquet → one file per historical
+          #     season, fetched on-demand only when a non-current season is
+          #     picked in the Value tab. Kept per-season (NOT concatenated) so
+          #     each fetch stays ~6MB; a merged ~60MB file would be a 10x
+          #     page-load regression on the default view.
           if gh release download blog-latest -p "game_logs.parquet" -D blog/; then
             mv blog/game_logs.parquet blog/game-logs.parquet
-            echo "Downloaded game-logs.parquet"
+            echo "Downloaded game-logs.parquet (current-season default)"
           else
             echo "::warning::game_logs.parquet not available — Value tab will be empty"
+          fi
+
+          # Per-season historical files (game_logs_<season>.parquet). The glob
+          # excludes the alias above (it has no _<season> suffix), so there's no
+          # double-download. Each is renamed game-logs-<season>.parquet so the
+          # R2 upload loop ships it to football/game-logs-<season>.parquet
+          # verbatim. Glob-style download mirrors action_wpa_*.parquet below.
+          GL_SEASONS=0
+          if gh release download blog-latest -p "game_logs_*.parquet" -D blog/; then
+            for f in blog/game_logs_*.parquet; do
+              [ -e "$f" ] || continue
+              season=${f#blog/game_logs_}        # -> 2024-2025.parquet
+              mv "$f" "blog/game-logs-${season}"
+              GL_SEASONS=$((GL_SEASONS + 1))
+            done
+            echo "Downloaded $GL_SEASONS per-season game-logs file(s)"
+          else
+            echo "::warning::No per-season game_logs_*.parquet on blog-latest — historical Value tab will be empty"
           fi
 
           # Action equity (per-action EPV credit — optional, used by chain builder)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,8 @@ source("scripts/build_chains_ci.R")     # Possession chains with EPV equity
 |------|--------|---------|
 | `ratings.parquet` | `build_blog_data.R` | Seasonal player ratings |
 | `player-details.parquet` | `build_player_meta.R` | Player bio (id, name, team, league, position) |
-| `game-logs.parquet` | panna step 10b → `blog-latest` pass-through | Per-match EPV+WPA+PSV value metrics |
+| `game-logs.parquet` | panna step 10b → `blog-latest` pass-through | Per-match EPV+WPA+PSV value metrics (current-season alias, fast default) |
+| `game-logs-<season>.parquet` | panna step 10b per-season → `blog-latest` pass-through | Historical per-season value metrics, fetched on-demand by the blog Value tab (kept per-season, ~6MB each — never concatenated) |
 | `chains-{CODE}.parquet` | `build_chains_ci.R` + equity join | Possession chains with per-action EPV equity |
 | `predictions.parquet` | panna step 10 → `blog-latest` pass-through | Match predictions |
 


### PR DESCRIPTION
Promotes `dev` to `main`.

## Headline change — historical game-logs on R2 (`6093eec`)
The blog Value tab was empty for every season except current, because `build-blog-data.yml` only passed the current-season alias (`game_logs.parquet`) through to R2. The 11 historical per-season files already existed on the `blog-latest` release (backfilled 2026-04-21) but were never downloaded or uploaded.

The "Game logs" step now also globs `game_logs_<season>.parquet`, renames each to `game-logs-<season>.parquet`, and lets the existing R2 upload loop ship them to `football/game-logs-<season>.parquet`. Kept per-season (not concatenated) so the blog fetches on-demand (~6MB) without regressing the default player-stats page load.

**Verified live:** a manual `workflow_dispatch` on `dev` uploaded all 11 `football/game-logs-<season>.parquet` files plus the unchanged alias (confirmed in the run log). Schema parity with the current alias verified (identical 32 cols, no type drift) — no `force_rebuild` needed.

Also bundles CLAUDE.md update (new R2 deliverable row) and the prior `feat(player-positions)` commit (`18615a5`) already on `dev`.

## Commits
- `6093eec` build-blog-data: ship historical per-season game-logs to R2
- `18615a5` feat(player-positions): per-match hybrid from Opta side + formation

🤖 Generated with [Claude Code](https://claude.com/claude-code)