### PR TITLE
Promote dev → main: own-goal xG guard + shootout-WPA R2 passthrough

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -84,6 +84,17 @@ jobs:
             echo "::warning::No per-season game_logs_*.parquet on blog-latest — historical Value tab will be empty"
           fi
 
+          # Shootout WPA (per-player penalty-shootout win-prob-added — optional).
+          # Pass straight through to R2 as football/shootout-wpa.parquet for the
+          # blog. Thin data (~1 kick/player) so it's a small file; absent for
+          # seasons with no shootouts in blog comps.
+          if gh release download blog-latest -p "shootout_wpa.parquet" -D blog/; then
+            mv blog/shootout_wpa.parquet blog/shootout-wpa.parquet
+            echo "Downloaded shootout-wpa.parquet"
+          else
+            echo "::notice::shootout_wpa.parquet not available — shootout WPA absent (no shootouts yet, or step 10d not run)"
+          fi
+
           # Action equity (per-action EPV credit — optional, used by chain builder)
           if gh release download blog-latest -p "action_equity.parquet" -D source/; then
             echo "Downloaded action_equity.parquet"

--- a/scripts/enrich_shots_xg.R
+++ b/scripts/enrich_shots_xg.R
@@ -72,6 +72,29 @@ if ("xg" %in% names(shots)) {
   cat("Added xG to all", nrow(shots), "rows\n")
 }
 
+# Own-goal guard. Opta logs an own goal as a goal (type_id == 16) at the
+# scoring player's location -- which is near their OWN goal, so the
+# attacking-right x-coordinate lands in their own half (x < 50). The xG model
+# reads that as a point-blank chance and returns ~0.97, which is meaningless:
+# an own goal has no shot xG by construction. Left in, these ~0.97 values are
+# the single largest xG entries (confirmed: every top-20 xG shot is an OG at
+# x = 0.6-7.4) and they pollute the blog shot map + inflate team/league xG
+# totals. Set them to NA (surface, never impute a fabricated number) so
+# downstream sum(xg, na.rm = TRUE) ignores them and the shot map can show
+# "OG -- no xG" rather than a fake 0.97. Mirrors panna's "own goals use EPV
+# not xG" convention (panna/CLAUDE.md).
+if ("type_id" %in% names(shots)) {
+  is_own_goal <- shots$type_id == 16L & !is.na(shots$x) & shots$x < 50
+  n_og <- sum(is_own_goal, na.rm = TRUE)
+  if (n_og > 0L) {
+    shots$xg[is_own_goal] <- NA_real_
+    cat("Own-goal guard: set xG = NA on", n_og,
+        "own-goal shot(s) (type_id == 16, x < 50)\n")
+  }
+} else {
+  cat("::warning:: no type_id column -- skipping own-goal xG guard\n")
+}
+
 cat("xG: mean =", round(mean(shots$xg, na.rm = TRUE), 4),
     ", total =", round(sum(shots$xg, na.rm = TRUE), 1),
     ", goals =", sum(shots$is_goal, na.rm = TRUE), "\n")


### PR DESCRIPTION
- `c75daf1` enrich_shots_xg: null out own-goal xG (own-half goals, type_id 16
  at x<50 → NA, not a fake ~0.97). Keeps OG artifacts out of the blog shot map
  + league xG totals.
- `6cf8887` build-blog-data: pass `shootout_wpa.parquet` → R2 as
  `football/shootout-wpa.parquet` (mirrors game-logs passthrough; from panna
  step 10d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)