### PR TITLE
build_blog_data: carry Opta player_id into blog ratings.parquet

### DIFF
--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -135,7 +135,13 @@ panna_ratings <- enriched |>
   ) |>
   ungroup() |>
   select(
-    panna_rank, player_name, team, league, position,
+    panna_rank,
+    # Opta player_id (UUID) — carried through so the blog can join players to
+    # external registers (e.g. reep → Wikidata) by a stable ID instead of
+    # fuzzy name matching, and route profiles by #id= rather than #name=.
+    # any_of() so the build still works if a future source lacks it.
+    any_of("player_id"),
+    player_name, team, league, position,
     panna = xrapm, offense, defense, spm_overall,
     total_minutes,
     panna_percentile,


### PR DESCRIPTION
Carries the Opta `player_id` (string UUID) through to `blog/ratings.parquet`.
It was already the join key but got dropped from the output `select()`, leaving
the blog with only `player_name` — which forced fuzzy name matching (~38%
ambiguous) to join players to external registers.

**Why now:** unblocks the football headshot + bio work — a clean
`player_id → reep key_opta → Wikidata QID + dob/nationality` join (no fuzzy
matching), plus `#id=` profile routing instead of collision-prone `#name=`.

Single additive column, `any_of("player_id")` so the build still works if a
future source ever lacks it. Verified all three source parquets
(seasonal_xrapm / seasonal_spm / player_metadata) carry `player_id`.

Already dispatched `Build blog data` on `dev` to land it in live R2 immediately;
merging here keeps it across future automatic (main) runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)