### PR TITLE
WC blog data: match-stats-WC shard + knockout-probs passthrough

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -105,7 +105,7 @@ jobs:
 
           # World Cup 2026 blog data (panna step 12 → blog-latest). Optional —
           # passed straight through to R2 football/ for the blog's WC section.
-          for wcf in wc2026_predictions wc2026_simulation wc2026_groups wc2026_team_strength wc2026_squads; do
+          for wcf in wc2026_predictions wc2026_simulation wc2026_groups wc2026_team_strength wc2026_squads wc2026_knockout_probs; do
             if gh release download blog-latest -p "${wcf}.parquet" -D blog/; then
               echo "Downloaded ${wcf}.parquet"
             else

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -105,7 +105,7 @@ jobs:
 
           # World Cup 2026 blog data (panna step 12 → blog-latest). Optional —
           # passed straight through to R2 football/ for the blog's WC section.
-          for wcf in wc2026_predictions wc2026_simulation wc2026_groups wc2026_team_strength; do
+          for wcf in wc2026_predictions wc2026_simulation wc2026_groups wc2026_team_strength wc2026_squads; do
             if gh release download blog-latest -p "${wcf}.parquet" -D blog/; then
               echo "Downloaded ${wcf}.parquet"
             else

--- a/scripts/rebuild_match_stats.R
+++ b/scripts/rebuild_match_stats.R
@@ -20,7 +20,14 @@ build_shard <- function(comp, code) {
            bigChanceCreated, totalAttAssist) |>
     collect()
 
-  if (nrow(league_stats) == 0) return(invisible(NULL))
+  if (nrow(league_stats) == 0) {
+    # ::warning:: surfaces in the GHA run summary — a shard that silently
+    # fails to build leaves the stale R2 object in place with no signal
+    # anywhere else (upload step has no expected-file manifest).
+    cat("::warning::match-stats-", code, " NOT built -- 0 rows for competition '",
+        comp, "'\n", sep = "")
+    return(invisible(NULL))
+  }
 
   match_stats <- league_stats |>
     transmute(

--- a/scripts/rebuild_match_stats.R
+++ b/scripts/rebuild_match_stats.R
@@ -8,9 +8,7 @@ comp_to_code <- BLOG_COMP_TO_CODE
 # Use arrow dataset for lazy evaluation — avoids loading 247MB into R memory at once
 ds <- open_dataset("source/opta_player_stats.parquet", format = "parquet")
 
-for (comp in names(comp_to_code)) {
-  code <- comp_to_code[comp]
-
+build_shard <- function(comp, code) {
   league_stats <- ds |>
     filter(competition == comp) |>
     select(match_id, season, match_date, player_id, player_name, team_id,
@@ -22,7 +20,7 @@ for (comp in names(comp_to_code)) {
            bigChanceCreated, totalAttAssist) |>
     collect()
 
-  if (nrow(league_stats) == 0) next
+  if (nrow(league_stats) == 0) return(invisible(NULL))
 
   match_stats <- league_stats |>
     transmute(
@@ -59,4 +57,16 @@ for (comp in names(comp_to_code)) {
   write_parquet(match_stats, paste0("blog/match-stats-", code, ".parquet"))
   cat(code, ":", nrow(match_stats), "rows,", length(unique(match_stats$season)), "seasons\n")
   rm(league_stats, match_stats); gc(verbose = FALSE)
+  invisible(NULL)
 }
+
+for (comp in names(comp_to_code)) {
+  build_shard(comp, comp_to_code[comp])
+}
+
+# World Cup shard for the blog's WC Player Stats page (R2 key
+# football/match-stats-WC.parquet). Deliberately NOT in BLOG_COMP_TO_CODE —
+# that map also drives standings/chains steps where a tournament doesn't
+# belong. Ships all WC seasons (historical + 2026); the blog page filters
+# by match_date itself, so 2026 rows light up as the tournament is played.
+build_shard("World_Cup", "WC")


### PR DESCRIPTION
Pre-opener asks from the blog session.

- **`match-stats-WC.parquet`**: the blog's WC Player Stats page is deployed but empty — this shard doesn't exist on R2. `rebuild_match_stats.R` now emits it (same schema as club shards, 10,830 rows across the 2002–2022 World Cups; 2026 rows accumulate as matches are played). Kept out of `BLOG_COMP_TO_CODE` deliberately — that map also drives standings/chains where a tournament doesn't belong. Uploaded by the existing `blog/*.parquet` R2 glob.
- **`wc2026_knockout_probs.parquet` passthrough**: added to the WC download loop so the new panna step-11 export reaches R2 for the blog's in-browser simulator.

Validated locally: full shard rebuild ran clean, WC schema identical to club shards.

**Time-sensitive**: `build-blog-data.yml` runs from `main`, so the WC Player Stats page lights up only after this merges + a blog-data build runs. The opener is tonight.

Companion: peteowen1/panna dev→main (club_name + knockout export).

🤖 Generated with [Claude Code](https://claude.com/claude-code)