### PR TITLE
Raise SPM-join NA gate to 40% (new-league structural baseline)

### DIFF
--- a/league_strength.csv
+++ b/league_strength.csv
@@ -1,17 +1,23 @@
-strength_rank,league,league_name,confederation,offset_off,offset_def,offset_tot,method,n_obs,conf_elo_prior
-1,EURO,UEFA Euros,UEFA,0.072,0.001,0.073,career-direct,55,1500
-2,WC,World Cup,World,0.069,-0.007,0.062,career-direct,19,
-3,UCL,UEFA Champions League,UEFA,0,0,0,anchor,,1500
-4,ENG,Premier League,UEFA,-0.006,-0.002,-0.009,same-season,574,1500
-5,GER,Bundesliga,UEFA,-0.02,-0.002,-0.021,same-season,565,1500
-6,ESP,La Liga,UEFA,-0.024,-0.001,-0.025,same-season,593,1500
-7,ENG2,Championship,UEFA,-0.03,-0.002,-0.031,career-direct,48,1500
-8,BRA,Brazilian Serie A,CONMEBOL,-0.043,0.004,-0.039,chained,201,1519
-9,UEL,UEFA Europa League,UEFA,-0.057,0.004,-0.054,career-direct,261,1500
-10,FRA,Ligue 1,UEFA,-0.057,0.002,-0.054,same-season,341,1500
-11,ITA,Serie A,UEFA,-0.058,-0.002,-0.06,same-season,520,1500
-12,POR,Primeira Liga,UEFA,-0.117,0.008,-0.109,same-season,287,1500
-13,TUR,Super Lig,UEFA,-0.125,0.011,-0.114,same-season,116,1500
-14,UECL,UEFA Conference League,UEFA,-0.137,0.007,-0.129,career-direct,13,1500
-15,NED,Eredivisie,UEFA,-0.119,-0.021,-0.14,same-season,175,1500
-16,SCO,Scottish Premiership,UEFA,-0.212,-0.024,-0.236,same-season,50,1500
+strength_rank,league,league_name,confederation,offset_off,offset_def,offset_tot,method,n_obs,xrapm_mean,xrapm_rank,n_players_xrapm,conf_elo_prior
+1,EURO,UEFA Euros,UEFA,0.072,0.001,0.073,career-direct,55,,,,1500
+2,WC,World Cup,World,0.069,-0.007,0.062,career-direct,19,,,,
+3,UCL,UEFA Champions League,UEFA,0,0,0,anchor,,,,,1500
+4,ENG,Premier League,UEFA,-0.006,-0.002,-0.009,same-season,574,0.0426,1,403,1500
+5,GER,Bundesliga,UEFA,-0.02,-0.002,-0.021,same-season,565,0.0224,2,361,1500
+6,ESP,La Liga,UEFA,-0.024,-0.001,-0.025,same-season,593,0.0192,5,433,1500
+7,ENG2,Championship,UEFA,-0.03,-0.002,-0.031,career-direct,48,0.0055,14,567,1500
+8,BRA,Brazilian Serie A,CONMEBOL,-0.043,0.004,-0.039,chained,201,0.0143,6,388,1519
+9,UEL,UEFA Europa League,UEFA,-0.057,0.004,-0.054,career-direct,261,0.0018,17,79,1500
+10,FRA,Ligue 1,UEFA,-0.057,0.002,-0.054,same-season,341,0.0222,3,384,1500
+11,ITA,Serie A,UEFA,-0.058,-0.002,-0.06,same-season,520,0.02,4,427,1500
+12,POR,Primeira Liga,UEFA,-0.117,0.008,-0.109,same-season,287,0.0083,9,389,1500
+13,TUR,Super Lig,UEFA,-0.125,0.011,-0.114,same-season,116,0.0044,15,377,1500
+14,UECL,UEFA Conference League,UEFA,-0.137,0.007,-0.129,career-direct,13,-0.0253,19,96,1500
+15,NED,Eredivisie,UEFA,-0.119,-0.021,-0.14,same-season,175,0.007,12,364,1500
+16,SCO,Scottish Premiership,UEFA,-0.212,-0.024,-0.236,same-season,50,-0.0063,18,274,1500
+,ARG,Liga Profesional Argentina,CONMEBOL,,,,,,0.0062,13,519,1519
+,AUS,A-League,AFC,,,,,,0.0037,16,173,963
+,BEL,Belgian First Div,UEFA,,,,,,0.0072,10,333,1500
+,MEX,Liga MX,CONCACAF,,,,,,0.0099,8,373,1471
+,MLS,Major League Soccer,CONCACAF,,,,,,0.0072,11,443,1471
+,SAU,Saudi Pro League,AFC,,,,,,0.013,7,365,963

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -205,7 +205,11 @@ cat("SPM join:", nrow(panna_ratings) - na_spm, "/", nrow(panna_ratings),
 stopifnot(
   nrow(panna_ratings) == n_before - n_excl,  # joins didn't fan out (allowing the excluded comps)
   nrow(panna_ratings) > 0,
-  na_spm / nrow(panna_ratings) < 0.2
+  # Join-drift gate, not a coverage target: real drift looks like ~100% NA.
+  # Baseline NA is structural — calendar-year leagues (MLS/Argentina/Brazil)
+  # mid-season carry many players with xRAPM evidence but below SPM's
+  # threshold; measured 25.1% the day the 4 new leagues shipped (2026-06-11).
+  na_spm / nrow(panna_ratings) < 0.4
 )
 
 dir.create("blog", showWarnings = FALSE)

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -202,14 +202,24 @@ panna_ratings <- enriched |>
 na_spm <- sum(is.na(panna_ratings$spm_overall))
 cat("SPM join:", nrow(panna_ratings) - na_spm, "/", nrow(panna_ratings),
     "matched (", round(100 * na_spm / nrow(panna_ratings), 1), "% missing)\n")
+# Minutes-gated drift companion: heavy-minutes players join SPM far more
+# reliably than the tail, so a join-key drift spikes this rate toward 100%
+# while structural growth moves it slowly. NOT a pure minutes gate — players
+# in leagues without xmetrics features (the 2026-06 league additions) lack
+# SPM at any minutes, hence the nonzero baseline.
+heavy <- panna_ratings$total_minutes >= 900
+na_spm_heavy <- sum(heavy & is.na(panna_ratings$spm_overall))
+cat("SPM join (900+ min):", sum(heavy) - na_spm_heavy, "/", sum(heavy),
+    "matched (", round(100 * na_spm_heavy / max(sum(heavy), 1), 1), "% missing)\n")
 stopifnot(
   nrow(panna_ratings) == n_before - n_excl,  # joins didn't fan out (allowing the excluded comps)
   nrow(panna_ratings) > 0,
-  # Join-drift gate, not a coverage target: real drift looks like ~100% NA.
-  # Baseline NA is structural — calendar-year leagues (MLS/Argentina/Brazil)
-  # mid-season carry many players with xRAPM evidence but below SPM's
-  # threshold; measured 25.1% the day the 4 new leagues shipped (2026-06-11).
-  na_spm / nrow(panna_ratings) < 0.4
+  # Join-drift gates, not coverage targets: real drift looks like ~100% NA.
+  # Measured baselines on 2026-06-11 (the day MLS/Liga MX/Argentina/Saudi
+  # shipped): global 25.1% (mid-season calendar-year leagues carry many
+  # players with xRAPM evidence but no SPM row), 900+-minutes 15.5%.
+  na_spm / nrow(panna_ratings) < 0.4,
+  na_spm_heavy / max(sum(heavy), 1) < 0.3
 )
 
 dir.create("blog", showWarnings = FALSE)


### PR DESCRIPTION
The first blog build carrying the new-league ratings failed its SPM-join sanity gate: 25.1% NA vs the 20% limit. Diagnosis: not join drift — the missing-SPM players are concentrated in calendar-year leagues mid-season (Argentina 652, MLS 523, Brazil 460 + the continental comps), where players have xRAPM evidence but sit below SPM's threshold. Saudi/Liga MX (Aug–Jul seasons) join near-fully.

The gate's purpose is catching player_id join drift, which presents as ~100% NA — 40% preserves that while accepting the new structural baseline. Comment documents the measured 25.1% and why.

Blocks the new-league ratings from reaching the blog until merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)