### PR TITLE
blog: pool-independent Piero column + fill World Cup xG

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -254,7 +254,7 @@ jobs:
       # build because it LEFT JOINs piero from blog/ratings.parquet and reuses
       # blog/piero_reference.json for the rare squad players absent from ratings.
       # Both files are written by build_blog_data.R above. See
-      # scripts/enrich_squads_piero.R and PIERO-POOL-INDEPENDENCE.md.
+      # scripts/enrich_squads_piero.R and (parent repo) pannaverse/PIERO-POOL-INDEPENDENCE.md.
       - name: Enrich WC squads with Piero
         continue-on-error: true
         run: |

--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -30,6 +30,7 @@ jobs:
             any::dplyr
             any::tidyr
             any::xgboost
+            any::jsonlite
 
       - name: Download source data
         env:
@@ -248,6 +249,21 @@ jobs:
       - name: Build ratings parquet
         run: Rscript scripts/build_blog_data.R
 
+      # Attach the pool-independent `piero` column to the WC squads parquet
+      # (downloaded as a pass-through from panna step 12). Runs AFTER the ratings
+      # build because it LEFT JOINs piero from blog/ratings.parquet and reuses
+      # blog/piero_reference.json for the rare squad players absent from ratings.
+      # Both files are written by build_blog_data.R above. See
+      # scripts/enrich_squads_piero.R and PIERO-POOL-INDEPENDENCE.md.
+      - name: Enrich WC squads with Piero
+        continue-on-error: true
+        run: |
+          if [ -f blog/wc2026_squads.parquet ]; then
+            Rscript scripts/enrich_squads_piero.R
+          else
+            echo "::notice::Skipping squad Piero — wc2026_squads.parquet not downloaded"
+          fi
+
       - name: Build player details parquet
         continue-on-error: true
         run: |
@@ -292,7 +308,11 @@ jobs:
             Rscript -e '
               library(arrow); library(dplyr)
               source("scripts/league_config.R")
-              shots <- read_parquet("source/opta_shot_events.parquet") |> filter(competition %in% BLOG_COMPS)
+              # BLOG_SHOT_COMPS = BLOG_COMPS + World_Cup, so finished WC matches
+              # carry shot-level xG into match-shots.parquet (and thence into
+              # predictions xg_home/xg_away). WC is intentionally not in
+              # BLOG_COMPS — see league_config.R.
+              shots <- read_parquet("source/opta_shot_events.parquet") |> filter(competition %in% BLOG_SHOT_COMPS)
               has_xg <- "xg" %in% names(shots)
               cat("Source has xG:", has_xg, "\n")
               # Team names from lineups
@@ -384,17 +404,30 @@ jobs:
               team_xg <- ms |> filter(!is.na(xg)) |>
                 group_by(match_id, team_id) |>
                 summarise(xg = round(sum(xg, na.rm = TRUE), 2), .groups = "drop")
-              # Get home/away from match-stats team_position
-              codes <- BLOG_CODES
-              pos <- list()
-              for (code in codes) {
-                f <- paste0("blog/match-stats-", code, ".parquet")
-                if (file.exists(f)) {
-                  pos[[code]] <- read_parquet(f, col_select = c("match_id","team_id","team_position")) |>
-                    distinct(match_id, team_id, team_position)
-                }
+              # Home/away (team_position) per (match_id, team_id). Prefer
+              # opta_lineups.parquet: it covers EVERY scraped competition,
+              # including the World Cup, whereas the per-league
+              # match-stats-<code>.parquet files only exist for BLOG_CODES (no
+              # WC file → WC matches would be dropped by the inner_join and
+              # stay xG-NULL). Fall back to match-stats if lineups is absent.
+              pos <- NULL
+              lu_path <- "source/opta_lineups.parquet"
+              if (file.exists(lu_path)) {
+                pos <- read_parquet(lu_path, col_select = c("match_id","team_id","team_position")) |>
+                  distinct(match_id, team_id, team_position)
               }
-              pos <- bind_rows(pos)
+              if (is.null(pos) || nrow(pos) == 0) {
+                codes <- BLOG_CODES
+                pos_list <- list()
+                for (code in codes) {
+                  f <- paste0("blog/match-stats-", code, ".parquet")
+                  if (file.exists(f)) {
+                    pos_list[[code]] <- read_parquet(f, col_select = c("match_id","team_id","team_position")) |>
+                      distinct(match_id, team_id, team_position)
+                  }
+                }
+                pos <- bind_rows(pos_list)
+              }
               # Pivot to one row per match: xg_home, xg_away
               match_xg <- team_xg |>
                 inner_join(pos, by = c("match_id", "team_id")) |>

--- a/.github/workflows/daily-opta-scrape.yml
+++ b/.github/workflows/daily-opta-scrape.yml
@@ -109,6 +109,7 @@ jobs:
       # needs longer.
       timeout-minutes: ${{ fromJson(github.event.inputs.scrape_timeout_minutes || '35') }}
       env:
+        OPTA_OUTLET_ID: ${{ secrets.OPTA_OUTLET_ID }}
         INPUT_LEAGUES: ${{ github.event.inputs.leagues }}
         INPUT_SEASONS: ${{ github.event.inputs.seasons }}
         INPUT_RECENT: ${{ github.event.inputs.recent || 1 }}

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -262,7 +262,101 @@ stopifnot(
   na_spm_heavy / max(sum(heavy), 1) < 0.3
 )
 
+# ── Piero: pool-independent composite player rating ──────────────────────────
+# Faithful R port of inthegame-blog/football/player-rating.js
+# `computePlayerRating(rows, { scaleTo: "panna" })`. Computed ONCE here over the
+# canonical reference population (the full rated pool in ratings.parquet) and
+# shipped as a `piero` column, so the blog reads it directly instead of
+# recomputing pool-relative z-scores per page (which made the SAME player show
+# different Piero on the player vs World Cup pages — see PIERO-POOL-INDEPENDENCE.md).
+#
+# Method (mirrors the JS exactly):
+#   weights panna 0.5 / epr 0.3 / psr 0.2
+#   1. per-metric POPULATION mean/sd over finite values (sd <- 1 if degenerate)
+#   2. z_m = (value - mu_m) / sd_m  (NA where the metric is missing)
+#   3. blend = sum(w_m * z_m) / sum(w_m) over the metrics PRESENT for that row
+#      (weights renormalize on gaps; a panna-only player gets blend = z_panna)
+#   4. blend POPULATION mean/sd over finite blends
+#   5. piero = ((blend - mu_blend)/sd_blend) * sd_panna + mu_panna, rounded 4dp
+# `panna` here is the CAREER trait (never the season xrapm) — guaranteed because
+# panna_ratings$panna is the career column assembled above.
+PIERO_WEIGHTS <- c(panna = 0.5, epr = 0.3, psr = 0.2)
+piero_metrics <- names(PIERO_WEIGHTS)
+
+# Population mean/sd over finite values; sd falls back to 1 (matches JS meanSd:
+# empty -> {mu:0, sd:1}; sd uses /N, and `|| 1` makes a zero/degenerate sd -> 1).
+.piero_mean_sd <- function(x) {
+  v <- x[is.finite(x)]
+  if (length(v) == 0L) return(c(mu = 0, sd = 1))
+  mu <- mean(v)
+  sd <- sqrt(mean((v - mu)^2))           # population sd (/N), as in the JS
+  if (!is.finite(sd) || sd == 0) sd <- 1
+  c(mu = mu, sd = sd)
+}
+
+# Only the rows that survive into the published parquet form the reference pool.
+piero_present <- piero_metrics[piero_metrics %in% names(panna_ratings)]
+piero_stat <- lapply(piero_present, function(m) .piero_mean_sd(panna_ratings[[m]]))
+names(piero_stat) <- piero_present
+
+# Per-metric z matrix (NA where the metric column is absent or value missing).
+piero_z <- vapply(piero_metrics, function(m) {
+  if (!m %in% piero_present) return(rep(NA_real_, nrow(panna_ratings)))
+  (panna_ratings[[m]] - piero_stat[[m]]["mu"]) / piero_stat[[m]]["sd"]
+}, numeric(nrow(panna_ratings)))
+# vapply drops to a vector when nrow == 1; force a matrix so the rowSums work.
+if (is.null(dim(piero_z))) piero_z <- matrix(piero_z, nrow = nrow(panna_ratings),
+                                             dimnames = list(NULL, piero_metrics))
+
+# Renormalized weighted z-blend per row.
+w_vec  <- PIERO_WEIGHTS[piero_metrics]
+w_mat  <- matrix(w_vec, nrow = nrow(piero_z), ncol = length(w_vec), byrow = TRUE)
+have   <- is.finite(piero_z)
+acc    <- rowSums(ifelse(have, w_mat * piero_z, 0))
+sw     <- rowSums(ifelse(have, w_mat, 0))
+piero_blend <- ifelse(sw > 0, acc / sw, NA_real_)
+
+# Standardize the blend, then map onto panna's own mean/sd ("panna" scale).
+blend_stat <- .piero_mean_sd(piero_blend)
+panna_stat <- if ("panna" %in% names(piero_stat)) piero_stat[["panna"]] else c(mu = 0, sd = 1)
+piero <- round(((piero_blend - blend_stat["mu"]) / blend_stat["sd"]) *
+                 panna_stat["sd"] + panna_stat["mu"], 4)
+panna_ratings$piero <- unname(piero)
+
+cat("Piero:", sum(!is.na(panna_ratings$piero)), "/", nrow(panna_ratings),
+    "players rated (coverage:",
+    paste(sprintf("%s %d", piero_present,
+                  vapply(piero_present, function(m) sum(is.finite(panna_ratings[[m]])), integer(1))),
+          collapse = ", "), ")\n")
+
+# Persist the reference constants so the WC squads build (panna step 12) can
+# recompute Piero for the rare squad players absent from ratings.parquet using
+# the SAME population stats (NEVER the squad pool's own stats — that reproduces
+# the divergence bug). Squad players present in ratings.parquet get piero via a
+# left join on player_id instead (identical number for free).
+piero_reference <- list(
+  weights = as.list(PIERO_WEIGHTS),
+  metrics = lapply(piero_present, function(m) {
+    list(mean = unname(piero_stat[[m]]["mu"]), sd = unname(piero_stat[[m]]["sd"]))
+  }),
+  blend = list(mean = unname(blend_stat["mu"]), sd = unname(blend_stat["sd"])),
+  panna = list(mean = unname(panna_stat["mu"]), sd = unname(panna_stat["sd"])),
+  n_reference = nrow(panna_ratings),
+  built_at = format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+)
+names(piero_reference$metrics) <- piero_present
+
 dir.create("blog", showWarnings = FALSE)
+if (requireNamespace("jsonlite", quietly = TRUE)) {
+  jsonlite::write_json(piero_reference, "blog/piero_reference.json",
+                       auto_unbox = TRUE, pretty = TRUE, digits = 10)
+  cat("Piero reference constants written to blog/piero_reference.json\n")
+} else {
+  # jsonlite absent: the `piero` column still ships (it needs no JSON); only the
+  # WC-squad recompute-from-reference fallback loses its constants source.
+  warning("jsonlite not installed — skipping blog/piero_reference.json (piero column still written)")
+}
+
 write_parquet(panna_ratings, "blog/ratings.parquet")
 cat("ratings:", nrow(panna_ratings), "players (season", latest_season, ")\n")
 

--- a/scripts/build_blog_data.R
+++ b/scripts/build_blog_data.R
@@ -268,7 +268,8 @@ stopifnot(
 # canonical reference population (the full rated pool in ratings.parquet) and
 # shipped as a `piero` column, so the blog reads it directly instead of
 # recomputing pool-relative z-scores per page (which made the SAME player show
-# different Piero on the player vs World Cup pages — see PIERO-POOL-INDEPENDENCE.md).
+# different Piero on the player vs World Cup pages — see the rationale doc
+# pannaverse/PIERO-POOL-INDEPENDENCE.md in the parent repo).
 #
 # Method (mirrors the JS exactly):
 #   weights panna 0.5 / epr 0.3 / psr 0.2

--- a/scripts/enrich_squads_piero.R
+++ b/scripts/enrich_squads_piero.R
@@ -15,11 +15,11 @@
 #      squad players are the same career-trait players, so the overlap gets the
 #      IDENTICAL number for free.
 #   2. For squad players absent from ratings.parquet (rare untracked-league
-#      call-ups), recompute piero using the PERSISTED reference constants from
-#      piero_reference.json — NEVER the squad pool's own stats (that reproduces
-#      the divergence bug). NA if a required metric is missing.
+#      call-ups), piero is left NA (see the note at the join below for why a
+#      recompute is deliberately not done).
 #
-# Idempotent: re-running overwrites any existing `piero` column.
+# Rationale doc: pannaverse/PIERO-POOL-INDEPENDENCE.md (in the parent repo, not
+# pannadata). Idempotent: re-running overwrites any existing `piero` column.
 
 suppressPackageStartupMessages({ library(arrow); library(dplyr) })
 
@@ -50,6 +50,12 @@ if (!"piero" %in% names(ratings)) {
 
 # 1. LEFT JOIN piero from ratings on player_id (identical numbers for the overlap).
 squads$piero <- NULL  # drop any stale column so the join is the single source
+# Coerce the join key to character on BOTH sides. wc2026_squads (panna step 12)
+# and ratings.parquet (this build) are written by different codebases, so a
+# silent int64-vs-string player_id type mismatch would make left_join match 0
+# rows and ship an all-NA piero. Character is the safe common type.
+squads$player_id  <- as.character(squads$player_id)
+ratings$player_id <- as.character(ratings$player_id)
 # One piero per player_id (ratings.parquet is already unique per player, but
 # guard against any dup so the join can't fan out the squad rows).
 piero_lut <- ratings |>
@@ -59,70 +65,30 @@ piero_lut <- ratings |>
 squads <- left_join(squads, piero_lut, by = "player_id")
 n_joined <- sum(!is.na(squads$piero))
 cat("Piero join:", n_joined, "/", nrow(squads), "squad players matched from ratings.parquet\n")
+# Coverage gate — squad players are tracked-league internationals, so the vast
+# majority are in ratings.parquet. A near-zero join means player_id drift, not a
+# real roster: fail loudly. (The workflow step is continue-on-error, so this
+# surfaces as a red step without blocking the rest of the build, and the blog
+# falls back to its client-side compute — never wrong data.)
+if (n_joined == 0)
+  stop("Piero squad join matched 0 rows — player_id type/key drift between wc2026_squads and ratings.parquet")
+if (n_joined / nrow(squads) < 0.5)
+  warning(sprintf("Piero squad join coverage only %.0f%% (%d/%d) — possible player_id drift",
+                  100 * n_joined / nrow(squads), n_joined, nrow(squads)))
 
-# 2. Unmatched squad players (absent from ratings.parquet — rare untracked-league
-# call-ups). RESOLVED (was TODO): leave their piero = NA rather than recompute.
-# The squad parquet's `panna` is the LATEST-SEASON xrapm (panna step 12 renames
-# it), not the career trait the reference constants were calibrated on, so a
-# recompute would ship a mildly miscalibrated number for these players. An
-# honest NA ("—" on the page) beats a wrong rating — the whole point of this fix
-# is trust. Flip RECOMPUTE_UNMATCHED to TRUE only once step 12 carries the
-# CAREER panna into wc2026_squads (then the recompute below is exact).
-RECOMPUTE_UNMATCHED <- FALSE
+# 2. Squad players absent from ratings.parquet (rare untracked-league call-ups)
+# keep piero = NA. We deliberately do NOT recompute from the reference constants:
+# the squad parquet's `panna` is the LATEST-SEASON xrapm (renamed by panna step
+# 12's 12_export_wc2026_blog.R), not the career trait the constants were
+# calibrated on, so a recompute would ship a mildly miscalibrated number. An
+# honest NA ("—" on the page) beats a wrong rating. If step 12 is later changed
+# to carry the CAREER panna into wc2026_squads, an exact recompute (z-blend over
+# the persisted reference mean/sd, NEVER the squad pool's own stats) can be
+# reinstated here.
 unmatched <- which(is.na(squads$piero))
-if (RECOMPUTE_UNMATCHED && length(unmatched) > 0 && file.exists(ref_path) &&
-    requireNamespace("jsonlite", quietly = TRUE)) {
-  ref <- jsonlite::fromJSON(ref_path, simplifyVector = FALSE)
-  metric_names <- names(ref$metrics)          # e.g. panna / epr / psr present in ref
-  weights <- unlist(ref$weights[metric_names])
-
-  recompute_piero <- function(row) {
-    # weighted renormalized z-blend over the metrics PRESENT for this row,
-    # using the REFERENCE pool's mean/sd (never the squad pool's).
-    acc <- 0; sw <- 0
-    for (m in metric_names) {
-      v <- suppressWarnings(as.numeric(row[[m]]))
-      if (length(v) == 1 && is.finite(v)) {
-        mu <- ref$metrics[[m]]$mean; sd <- ref$metrics[[m]]$sd
-        z <- (v - mu) / sd
-        acc <- acc + weights[[m]] * z
-        sw  <- sw  + weights[[m]]
-      }
-    }
-    if (sw <= 0) return(NA_real_)
-    blend <- acc / sw
-    round(((blend - ref$blend$mean) / ref$blend$sd) * ref$panna$sd + ref$panna$mean, 4)
-  }
-
-  # CAVEAT on the recompute path (unmatched squad players ONLY — the common
-  # join path above is unaffected and correct):
-  # The reference constants were built on ratings.parquet's `panna`, which is the
-  # CAREER trait. But panna step 12 (12_export_wc2026_blog.R, ~L218-222) builds
-  # the squad parquet's `panna` by renaming the LATEST-SEASON `xrapm` — i.e. a
-  # SEASON metric, not the career trait. Feeding that into the career-calibrated
-  # reference is a scale mismatch for the handful of recomputed players.
-  # TODO(human): decide the right behaviour for untracked-league call-ups —
-  # either (a) have step 12 carry the career `panna` into wc2026_squads (then
-  # this recompute is exact), or (b) leave their piero = NA rather than ship a
-  # mildly miscalibrated number. Until then this recompute is best-effort and
-  # only affects players genuinely absent from ratings.parquet.
-  needed <- intersect(metric_names, names(squads))
-  if (length(needed) == length(metric_names)) {
-    for (i in unmatched) {
-      squads$piero[i] <- recompute_piero(as.list(squads[i, metric_names, drop = FALSE]))
-    }
-    n_recomp <- sum(!is.na(squads$piero[unmatched]))
-    cat("Piero recompute (reference constants):", n_recomp, "/", length(unmatched),
-        "unmatched squad players rated\n")
-  } else {
-    cat("::warning::squads missing metric column(s) [",
-        paste(setdiff(metric_names, names(squads)), collapse = ", "),
-        "] — leaving unmatched rows' piero = NA\n")
-  }
-} else if (length(unmatched) > 0) {
-  cat("::warning::", length(unmatched), "unmatched squad players and no",
-      ref_path, "/jsonlite — their piero stays NA\n")
-}
+if (length(unmatched) > 0)
+  cat(sprintf("::notice::%d squad players absent from ratings.parquet — piero left NA\n",
+              length(unmatched)))
 
 write_parquet(squads, squads_path)
 cat("wc2026_squads.parquet:", sum(!is.na(squads$piero)), "/", nrow(squads),

--- a/scripts/enrich_squads_piero.R
+++ b/scripts/enrich_squads_piero.R
@@ -1,0 +1,129 @@
+#!/usr/bin/env Rscript
+# enrich_squads_piero.R — add the pool-independent `piero` column to
+# blog/wc2026_squads.parquet.
+#
+# Piero is computed ONCE in build_blog_data.R over the canonical reference
+# population (the full rated pool in blog/ratings.parquet) and persisted there
+# as a `piero` column plus blog/piero_reference.json (the reference constants).
+# See PIERO-POOL-INDEPENDENCE.md.
+#
+# wc2026_squads.parquet is built upstream by panna step 12 and arrives here as a
+# pass-through file (it has no access to ratings.parquet at its own build time),
+# so we attach piero here, where ratings.parquet exists. Two paths, preferred
+# first:
+#   1. LEFT JOIN piero from ratings.parquet on player_id — the common case;
+#      squad players are the same career-trait players, so the overlap gets the
+#      IDENTICAL number for free.
+#   2. For squad players absent from ratings.parquet (rare untracked-league
+#      call-ups), recompute piero using the PERSISTED reference constants from
+#      piero_reference.json — NEVER the squad pool's own stats (that reproduces
+#      the divergence bug). NA if a required metric is missing.
+#
+# Idempotent: re-running overwrites any existing `piero` column.
+
+suppressPackageStartupMessages({ library(arrow); library(dplyr) })
+
+squads_path  <- "blog/wc2026_squads.parquet"
+ratings_path <- "blog/ratings.parquet"
+ref_path     <- "blog/piero_reference.json"
+
+if (!file.exists(squads_path)) {
+  cat("::notice::", squads_path, "not present — skipping Piero enrichment\n")
+  quit(status = 0)
+}
+if (!file.exists(ratings_path)) {
+  cat("::warning::", ratings_path, "not present — cannot attach Piero to squads\n")
+  quit(status = 0)
+}
+
+squads  <- as.data.frame(read_parquet(squads_path))
+ratings <- as.data.frame(read_parquet(ratings_path))
+
+if (!"player_id" %in% names(squads) || !"player_id" %in% names(ratings)) {
+  cat("::warning::player_id missing from squads or ratings — skipping Piero enrichment\n")
+  quit(status = 0)
+}
+if (!"piero" %in% names(ratings)) {
+  cat("::warning::ratings.parquet has no piero column (old build?) — skipping Piero enrichment\n")
+  quit(status = 0)
+}
+
+# 1. LEFT JOIN piero from ratings on player_id (identical numbers for the overlap).
+squads$piero <- NULL  # drop any stale column so the join is the single source
+# One piero per player_id (ratings.parquet is already unique per player, but
+# guard against any dup so the join can't fan out the squad rows).
+piero_lut <- ratings |>
+  select(player_id, piero) |>
+  filter(!is.na(player_id)) |>
+  group_by(player_id) |> slice(1) |> ungroup()
+squads <- left_join(squads, piero_lut, by = "player_id")
+n_joined <- sum(!is.na(squads$piero))
+cat("Piero join:", n_joined, "/", nrow(squads), "squad players matched from ratings.parquet\n")
+
+# 2. Unmatched squad players (absent from ratings.parquet — rare untracked-league
+# call-ups). RESOLVED (was TODO): leave their piero = NA rather than recompute.
+# The squad parquet's `panna` is the LATEST-SEASON xrapm (panna step 12 renames
+# it), not the career trait the reference constants were calibrated on, so a
+# recompute would ship a mildly miscalibrated number for these players. An
+# honest NA ("—" on the page) beats a wrong rating — the whole point of this fix
+# is trust. Flip RECOMPUTE_UNMATCHED to TRUE only once step 12 carries the
+# CAREER panna into wc2026_squads (then the recompute below is exact).
+RECOMPUTE_UNMATCHED <- FALSE
+unmatched <- which(is.na(squads$piero))
+if (RECOMPUTE_UNMATCHED && length(unmatched) > 0 && file.exists(ref_path) &&
+    requireNamespace("jsonlite", quietly = TRUE)) {
+  ref <- jsonlite::fromJSON(ref_path, simplifyVector = FALSE)
+  metric_names <- names(ref$metrics)          # e.g. panna / epr / psr present in ref
+  weights <- unlist(ref$weights[metric_names])
+
+  recompute_piero <- function(row) {
+    # weighted renormalized z-blend over the metrics PRESENT for this row,
+    # using the REFERENCE pool's mean/sd (never the squad pool's).
+    acc <- 0; sw <- 0
+    for (m in metric_names) {
+      v <- suppressWarnings(as.numeric(row[[m]]))
+      if (length(v) == 1 && is.finite(v)) {
+        mu <- ref$metrics[[m]]$mean; sd <- ref$metrics[[m]]$sd
+        z <- (v - mu) / sd
+        acc <- acc + weights[[m]] * z
+        sw  <- sw  + weights[[m]]
+      }
+    }
+    if (sw <= 0) return(NA_real_)
+    blend <- acc / sw
+    round(((blend - ref$blend$mean) / ref$blend$sd) * ref$panna$sd + ref$panna$mean, 4)
+  }
+
+  # CAVEAT on the recompute path (unmatched squad players ONLY — the common
+  # join path above is unaffected and correct):
+  # The reference constants were built on ratings.parquet's `panna`, which is the
+  # CAREER trait. But panna step 12 (12_export_wc2026_blog.R, ~L218-222) builds
+  # the squad parquet's `panna` by renaming the LATEST-SEASON `xrapm` — i.e. a
+  # SEASON metric, not the career trait. Feeding that into the career-calibrated
+  # reference is a scale mismatch for the handful of recomputed players.
+  # TODO(human): decide the right behaviour for untracked-league call-ups —
+  # either (a) have step 12 carry the career `panna` into wc2026_squads (then
+  # this recompute is exact), or (b) leave their piero = NA rather than ship a
+  # mildly miscalibrated number. Until then this recompute is best-effort and
+  # only affects players genuinely absent from ratings.parquet.
+  needed <- intersect(metric_names, names(squads))
+  if (length(needed) == length(metric_names)) {
+    for (i in unmatched) {
+      squads$piero[i] <- recompute_piero(as.list(squads[i, metric_names, drop = FALSE]))
+    }
+    n_recomp <- sum(!is.na(squads$piero[unmatched]))
+    cat("Piero recompute (reference constants):", n_recomp, "/", length(unmatched),
+        "unmatched squad players rated\n")
+  } else {
+    cat("::warning::squads missing metric column(s) [",
+        paste(setdiff(metric_names, names(squads)), collapse = ", "),
+        "] — leaving unmatched rows' piero = NA\n")
+  }
+} else if (length(unmatched) > 0) {
+  cat("::warning::", length(unmatched), "unmatched squad players and no",
+      ref_path, "/jsonlite — their piero stays NA\n")
+}
+
+write_parquet(squads, squads_path)
+cat("wc2026_squads.parquet:", sum(!is.na(squads$piero)), "/", nrow(squads),
+    "players have piero (written", squads_path, ")\n")

--- a/scripts/league_config.R
+++ b/scripts/league_config.R
@@ -12,6 +12,17 @@ BLOG_COMP_TO_CODE <- c(
 BLOG_COMPS <- names(BLOG_COMP_TO_CODE)
 BLOG_CODES <- unname(BLOG_COMP_TO_CODE)
 
+# Competitions whose SHOTS we want in match-shots.parquet / predictions xG, even
+# though they are NOT first-class blog leagues (no BLOG_CODE, no match-stats
+# file, no league badge). The World Cup is keyed by tournament YEAR not a club
+# season, and its `league` in match_predictions.parquet is "WC" while its
+# `competition` in opta_shot_events.parquet is "World_Cup" (see panna
+# R/opta_loaders.R league map). Adding it here lets finished WC matches get
+# xg_home/xg_away from the same panna XGBoost shot-xG model as club games,
+# joined onto predictions by match_id — without pulling WC into BLOG_COMPS
+# (which drives match-stats / league-xg and would have wider side effects).
+BLOG_SHOT_COMPS <- c(BLOG_COMPS, "World_Cup")
+
 # Competitions rated upstream but deliberately EXCLUDED from the blog outputs.
 # CAF_CL and Tunisian_Ligue_1 are no longer treated as tier-2 for the blog, and
 # they carry ~0% box-score skills coverage (the skills loader never picks them up),

--- a/scripts/opta/opta_scraper.py
+++ b/scripts/opta/opta_scraper.py
@@ -22,6 +22,7 @@ Data extracted:
 - fixtures: Match fixtures with scores and statuses
 """
 
+import os
 import requests
 import json
 import re
@@ -220,7 +221,10 @@ class OptaScraper:
     """Scrapes Opta data from TheAnalyst API"""
 
     BASE_URL = "https://api.performfeeds.com/soccerdata"
-    PROVIDER_ID = "1mjq6w6ezkxe611ykkj8rgz7f1"
+    # Opta/Stats Perform public outlet token. Overridable via env (OPTA_OUTLET_ID,
+    # set as a GitHub Actions secret); falls back to the public default so the
+    # scrape works whether or not the secret is configured.
+    PROVIDER_ID = os.environ.get("OPTA_OUTLET_ID") or "1mjq6w6ezkxe611ykkj8rgz7f1"
 
     # Rotating User-Agent pool to help prevent rate limiting
     # Mimics various browsers on Windows/Mac for realistic traffic patterns


### PR DESCRIPTION
Upstream fixes for two blog issues (full spec: `pannaverse/PIERO-POOL-INDEPENDENCE.md`).

## 1. Pool-independent Piero
Piero was computed client-side on the blog and was **pool-relative** — the same player showed a different number on the player page vs the World Cup page. Now computed once here over the canonical reference pool (`ratings.parquet`) and shipped as a `piero` column:
- `build_blog_data.R` — faithful R port of `player-rating.js` `computePlayerRating(scaleTo:"panna")`; writes `piero` + `blog/piero_reference.json`.
- `enrich_squads_piero.R` (new) — LEFT JOINs `piero` onto `wc2026_squads` by `player_id` (identical numbers for the overlap); unmatched squad players left `NA` (their squad `panna` is seasonal xrapm, not the career trait — honest NA over a miscalibrated recompute).
- `build-blog-data.yml` — `+jsonlite`, `+` "Enrich WC squads with Piero" step.

## 2. World Cup xG was NULL in predictions.parquet
Two filters dropped it: the match-shots build excluded WC (`competition %in% BLOG_COMPS`), and the predictions-xG step resolved home/away only from per-league `match-stats` files (no WC file). Fixed:
- `league_config.R` — `BLOG_SHOT_COMPS = BLOG_COMPS + "World_Cup"` (WC stays out of `BLOG_COMPS`).
- `build-blog-data.yml` — source home/away from the universal `opta_lineups.parquet` (covers WC), match-stats as fallback. Home/away is a stable fixture property both agree on, so club xG is unchanged.

## Verify after the next build
- `ratings.parquet` + `wc2026_squads.parquet` carry `piero`; an overlap player matches to 4dp across both.
- `predictions.parquet` WC rows (finished) have non-null `xg_home`/`xg_away` matching the worker's live values.

Then the blog follow-up reads `row.piero` instead of recomputing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)