### PR TITLE
xGOT enrichment: fail loudly on feature drift [dev→main]

### DIFF
--- a/scripts/enrich_shots_xgot.R
+++ b/scripts/enrich_shots_xgot.R
@@ -76,8 +76,13 @@ features <- data.frame(
 
 missing_feat <- setdiff(feature_cols, names(features))
 if (length(missing_feat) > 0) {
-  cat("::warning:: model expects features not built here:", paste(missing_feat, collapse=", "), "\n")
-  for (col in missing_feat) features[[col]] <- 0
+  # Fatal, NOT a 0-fill: a missing model feature means the placement/base
+  # feature logic here has drifted from panna::.create_placement_features /
+  # .create_shot_features. Predicting on 0-filled features would ship
+  # plausible-but-wrong xGOT to the canonical parquet — refuse instead.
+  stop("xgot_model expects features this script does not build: ",
+       paste(missing_feat, collapse = ", "),
+       " — feature logic has drifted from panna; refusing to predict.")
 }
 
 on_target <- shots$type_id %in% c(15L, 16L)


### PR DESCRIPTION
## dev → main — xGOT enrichment fix

Follow-up to the merged xGOT PR (#71), from the multi-agent review.

- **`0f8da89`** — `enrich_shots_xgot.R` now `stop()`s on a model-feature mismatch instead of logging a non-fatal `::warning::`, 0-filling the missing feature, and predicting on it. Feature-logic drift from panna's `.create_placement_features`/`.create_shot_features` would otherwise ship plausible-but-wrong xGOT to the canonical `opta_shot_events.parquet`. A drift must fail loudly, never be papered over with zeros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
