### PR TITLE
Issue-fix batch: penalty xG, season boundary, chains, manifest, pytest (#34 #36 #37 #60 #62 #76 #91)

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -270,7 +270,7 @@ jobs:
           if [ -f source/opta_lineups.parquet ]; then
             Rscript scripts/build_player_meta.R
           else
-            echo "::notice::Skipping player details — lineups file not available"
+            echo "::warning::Skipping player details — lineups file not available"
           fi
 
       - name: Build shot parquet
@@ -280,7 +280,7 @@ jobs:
               echo "::warning::Shot data build failed, continuing without shot charts"
             fi
           else
-            echo "::notice::Skipping shot data — source file not available"
+            echo "::warning::Skipping shot data — source file not available"
           fi
 
       - name: Download and filter player skills
@@ -348,7 +348,7 @@ jobs:
             Rscript scripts/rebuild_match_stats.R
             rm -f source/opta_player_stats.parquet  # free disk for chains
           else
-            echo "::notice::Skipping match-stats — source file not available"
+            echo "::warning::Skipping match-stats — source file not available"
           fi
 
       - name: Build league xG from match-shots
@@ -534,6 +534,54 @@ jobs:
             echo "ERROR: $upload_errors upload(s) failed"
             exit 1
           fi
+
+      # Expected-artifact manifest gate. Many build steps run with
+      # continue-on-error and `exit 0` on missing inputs, so a never-built
+      # shard leaves a STALE R2 object with no red signal (the upload only
+      # ships whatever files happen to exist). This step runs AFTER the upload
+      # — like the chains gate below — so it never blocks shipping the healthy
+      # files; it only reddens a degraded run.
+      #
+      # HARD-FAIL tier (always-rebuilt every healthy run): the 14 match-stats
+      # shards (13 BLOG_CODES from scripts/league_config.R + WC) plus ratings,
+      # player-details, and match-shots. Any missing → exit 1.
+      #
+      # WARN tier (optional upstream / pass-through — absence is expected, not
+      # a degraded build): player-positions, player-skills, predictions,
+      # game-logs*, wc2026_*, shootout-wpa.
+      - name: Fail run if expected blog artifacts are missing
+        run: |
+          # 13 BLOG_CODES from scripts/league_config.R + the WC shard.
+          HARD_MATCH_STATS="ENG ENG2 ESP FRA GER ITA NED POR SCO TUR UCL UEL UECL WC"
+          missing=0
+          for code in $HARD_MATCH_STATS; do
+            f="blog/match-stats-${code}.parquet"
+            if [ ! -f "$f" ]; then
+              echo "::error::Missing expected artifact: $f (match-stats shard never built — stale R2 object)"
+              missing=$((missing + 1))
+            fi
+          done
+          for f in blog/ratings.parquet blog/player-details.parquet blog/match-shots.parquet; do
+            if [ ! -f "$f" ]; then
+              echo "::error::Missing expected artifact: $f (load-bearing build step skipped — stale R2 object)"
+              missing=$((missing + 1))
+            fi
+          done
+
+          # WARN tier — optional upstream downloads / pass-throughs. Absence is
+          # surfaced for visibility but does not fail the run.
+          for f in blog/player-positions.parquet blog/player-skills.parquet \
+                   blog/predictions.parquet blog/shootout-wpa.parquet; do
+            [ -f "$f" ] || echo "::warning::Optional artifact missing: $f"
+          done
+          ls blog/game-logs*.parquet 1>/dev/null 2>&1 || echo "::warning::Optional artifact missing: blog/game-logs*.parquet"
+          ls blog/wc2026_*.parquet 1>/dev/null 2>&1 || echo "::warning::Optional artifact missing: blog/wc2026_*.parquet"
+
+          if [ "$missing" -gt 0 ]; then
+            echo "::error::$missing expected blog artifact(s) missing — degraded build shipped stale R2 objects"
+            exit 1
+          fi
+          echo "All hard-fail expected artifacts present."
 
       # The chains step runs with continue-on-error so the R2 upload still
       # ships healthy comps — but that keeps the run green even when comps

--- a/.github/workflows/daily-opta-scrape.yml
+++ b/.github/workflows/daily-opta-scrape.yml
@@ -29,6 +29,11 @@ on:
         required: false
         type: boolean
         default: false
+      dry_run:
+        description: 'Preview the scrape plan + reconcile counts, then exit before any API calls or writes'
+        required: false
+        type: boolean
+        default: false
       scrape_timeout_minutes:
         description: 'Override the Run Opta scraper timeout (default 35; raise for full-catalog rebuilds)'
         required: false
@@ -115,6 +120,7 @@ jobs:
         INPUT_RECENT: ${{ github.event.inputs.recent || 1 }}
         INPUT_TIER: ${{ github.event.inputs.tier || 2 }}
         INPUT_FORCE: ${{ github.event.inputs.force_rescrape }}
+        INPUT_DRY_RUN: ${{ github.event.inputs.dry_run }}
       run: |
         cd scripts/opta
         ARGS="--recent $INPUT_RECENT"
@@ -127,6 +133,9 @@ jobs:
         if [ "$INPUT_FORCE" = "true" ]; then
           ARGS="$ARGS --force"
         fi
+        if [ "$INPUT_DRY_RUN" = "true" ]; then
+          ARGS="$ARGS --dry-run"
+        fi
         # --seasons may contain spaces (tournament names like "2022 Qatar"),
         # so pass it as a quoted argument after the unquoted ARGS expansion.
         if [ -n "$INPUT_SEASONS" ]; then
@@ -136,6 +145,69 @@ jobs:
           echo "Running: python scrape_opta.py $ARGS"
           python scrape_opta.py $ARGS
         fi
+
+    # Scrape stats → job summary (pannadata#37). Reads the scrape_summary.json
+    # the scraper writes (totals + per-league-season results), renders a
+    # markdown table to $GITHUB_STEP_SUMMARY. if: always() so a failed/timed-out
+    # scrape still surfaces whatever progress landed. Must never fail the job —
+    # the Python is wrapped so any error degrades to a one-line note.
+    - name: Scrape stats job summary
+      if: always()
+      continue-on-error: true
+      run: |
+        python <<'PY' >> "$GITHUB_STEP_SUMMARY"
+        import json, os
+
+        path = "scripts/opta/data/scrape_summary.json"
+        try:
+            if not os.path.exists(path):
+                print("## Opta scrape stats\n\n_No scrape_summary.json produced_")
+                raise SystemExit(0)
+            with open(path) as f:
+                data = json.load(f)
+
+            totals = data.get("totals", {}) or {}
+            results = data.get("results", []) or []
+
+            print("## Opta scrape stats\n")
+            print(
+                "**Totals:** "
+                f"{totals.get('new_matches', 0)} new matches, "
+                f"{totals.get('total_matches', 0)} total matches, "
+                f"{totals.get('player_records', 0)} player records, "
+                f"{totals.get('shot_records', 0)} shot records\n"
+            )
+
+            ok = [r for r in results if not r.get("error")]
+            ok.sort(key=lambda r: r.get("new_matches", 0) or 0, reverse=True)
+            if ok:
+                print("| League | Season | New | Total | Players | Shots |")
+                print("|---|---|--:|--:|--:|--:|")
+                for r in ok:
+                    print(
+                        f"| {r.get('competition', '?')} "
+                        f"| {r.get('season', '?')} "
+                        f"| {r.get('new_matches', 0)} "
+                        f"| {r.get('total_matches', 0)} "
+                        f"| {r.get('player_records', 0)} "
+                        f"| {r.get('shot_records', 0)} |"
+                    )
+                print("")
+
+            errs = [r for r in results if r.get("error")]
+            if errs:
+                print("### Errors\n")
+                for r in errs:
+                    print(
+                        f"- **{r.get('competition', '?')} "
+                        f"{r.get('season', '?')}**: {r.get('error')}"
+                    )
+                print("")
+        except SystemExit:
+            raise
+        except Exception as e:
+            print(f"\n_Failed to render scrape stats: {e}_")
+        PY
 
     - name: Build consolidated parquet files
       env:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,38 @@
+name: Python Tests
+
+# Runs the Opta scraper unit tests (pytest) on any change under scripts/opta/.
+# Additive CI — does not touch the scraper or scrape workflows.
+
+on:
+  push:
+    paths:
+      - 'scripts/opta/**'
+      - '.github/workflows/python-tests.yml'
+  pull_request:
+    paths:
+      - 'scripts/opta/**'
+      - '.github/workflows/python-tests.yml'
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: scripts/opta/requirements-dev.txt
+
+      - name: Install dependencies
+        run: pip install -r scripts/opta/requirements-dev.txt
+
+      - name: Run pytest
+        # scripts/opta is the working directory so the scraper modules'
+        # bare-name imports (from scrape_opta import ...) resolve, and
+        # pytest.ini there excludes the live-API test_live_events.py.
+        working-directory: scripts/opta
+        run: pytest -q

--- a/scripts/build_chains_ci.R
+++ b/scripts/build_chains_ci.R
@@ -98,6 +98,13 @@ comp_to_code <- c(BLOG_COMP_TO_CODE, World_Cup = "WC")
 dead_ball_types <- c(2L, 4L, 5L, 6L, 17L, 55L, 56L, 57L, 70L, 80L, 81L)
 non_play_types <- c(18L, 19L, 24L, 27L, 28L, 30L, 32L, 34L, 37L, 40L, 43L, 65L, 68L)
 shot_types <- c(13L, 14L, 15L, 16L)
+# Keeper rebound touches: GK Save (10), Claim (11), Punch (41), Blocked Pass
+# (50). These carry the DEFENDING team's team_id, so a shot -> save -> rebound
+# sequence flips attacking->defending->attacking and the raw team-change rule
+# below would split one possession into three (the 1-event save chain
+# mislabelled "lost_possession"). Treat them as transparent to possession
+# tracking so rebound possessions stay in one chain (pannadata#76).
+keeper_rebound_types <- c(10L, 11L, 41L, 50L)
 
 # Equity/WPA joins land on chain events by (match_id, event_id). Only chain
 # events that survive panna's SPADL conversion carry equity/wpa — SPADL drops
@@ -151,12 +158,19 @@ for (comp in blog_comps) {
   prev_team <- ""
   prev_match <- ""
   for (i in seq_len(nrow(events))) {
+    # A keeper rebound (save/claim/punch/block) must not end the attacking
+    # possession: it neither forces a new chain on the team-change clause nor
+    # advances prev_team. If the original attacker regains the ball the chain
+    # continues; if the defending team actually wins it, their NEXT event still
+    # has team_id != prev_team and triggers a split, so genuine turnovers are
+    # preserved (pannadata#76).
+    is_keeper_rebound <- events$type_id[i] %in% keeper_rebound_types
     new_chain <- events$match_id[i] != prev_match ||
-      (events$team_id[i] != prev_team && events$team_id[i] != "") ||
+      (!is_keeper_rebound && events$team_id[i] != prev_team && events$team_id[i] != "") ||
       events$type_id[i] %in% dead_ball_types
     if (new_chain) chain_n <- chain_n + 1L
     events$chain_number[i] <- chain_n
-    prev_team <- events$team_id[i]
+    if (!is_keeper_rebound) prev_team <- events$team_id[i]
     prev_match <- events$match_id[i]
   }
 

--- a/scripts/enrich_shots_xg.R
+++ b/scripts/enrich_shots_xg.R
@@ -95,6 +95,20 @@ if ("type_id" %in% names(shots)) {
   cat("::warning:: no type_id column -- skipping own-goal xG guard\n")
 }
 
+# Penalty override. panna's xG model is deliberately penalty-free (penalties
+# carry no shot-geometry signal), so a spot kick scores ~0.33 geometric xG --
+# meaningless. The EPV pipeline overrides penalties to a fixed conversion rate;
+# replicate that here so the blog shot map and team/league xG totals use the
+# right value. 0.76 == panna::PENALTY_XG.
+if ("situation" %in% names(shots)) {
+  is_pen <- !is.na(shots$situation) & tolower(shots$situation) == "penalty"
+  n_pen <- sum(is_pen)
+  shots$xg[is_pen] <- 0.76  # == panna::PENALTY_XG
+  cat("Penalty override: set xG = 0.76 on", n_pen, "penalty shot(s)\n")
+} else {
+  cat("::warning:: no situation column -- skipping penalty xG override\n")
+}
+
 cat("xG: mean =", round(mean(shots$xg, na.rm = TRUE), 4),
     ", total =", round(sum(shots$xg, na.rm = TRUE), 1),
     ", goals =", sum(shots$is_goal, na.rm = TRUE), "\n")

--- a/scripts/opta/conftest.py
+++ b/scripts/opta/conftest.py
@@ -1,0 +1,55 @@
+"""Shared pytest fixtures for the Opta scraper test suite.
+
+Lives in scripts/opta/ so the bare-name imports used by the scraper modules
+(`from scrape_opta import ...`) resolve when pytest is invoked from here.
+"""
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def opta_dir(tmp_path):
+    """A throwaway stand-in for pannadata/data/opta — an isolated tmp subdir.
+
+    reconcile_events_with_manifest() reads the consolidated
+    `opta_dir / "opta_events.parquet"`; tests write that file via the
+    `write_events` fixture below.
+    """
+    d = tmp_path / "opta"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def write_events(opta_dir):
+    """Write a real opta_events.parquet under opta_dir.
+
+    Exercises the genuine parquet schema path (pandas/pyarrow) rather than
+    monkeypatching, so reconcile's schema check and predicate-pushdown filter
+    run against an actual file.
+
+    Args:
+        rows: iterable of (match_id, competition, season) tuples.
+        extra_cols: optional dict {col_name: [values...]} of additional
+            columns to include (e.g. to add unrelated columns, or — when the
+            required trio is overridden via `columns=` — to model schema drift).
+        columns: optional explicit column list to write instead of the default
+            ("match_id", "competition", "season"). Use to drop/rename a
+            required column for the schema-drift test.
+
+    Returns the Path to the written parquet.
+    """
+    def _write(rows, extra_cols=None, columns=("match_id", "competition", "season")):
+        rows = list(rows)
+        data = {}
+        for i, col in enumerate(columns):
+            data[col] = [r[i] for r in rows]
+        if extra_cols:
+            for col, vals in extra_cols.items():
+                data[col] = list(vals)
+        df = pd.DataFrame(data)
+        path = opta_dir / "opta_events.parquet"
+        df.to_parquet(path, index=False)
+        return path
+
+    return _write

--- a/scripts/opta/pytest.ini
+++ b/scripts/opta/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+# rootdir is this directory (scripts/opta) because the scraper modules import
+# each other by BARE name (e.g. `from scrape_opta import ...`,
+# `from opta_scraper import ...`). pytest must be invoked from here so those
+# bare imports resolve. The presence of this file makes scripts/opta the
+# rootdir, and `testpaths = .` keeps collection scoped here.
+testpaths = .
+python_files = test_*.py
+# test_live_events.py hits the LIVE Opta API and instantiates a scraper on
+# import — it is a manual exploratory script, never an automated test.
+addopts = --ignore=test_live_events.py

--- a/scripts/opta/requirements-dev.txt
+++ b/scripts/opta/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8.0,<9.0

--- a/scripts/opta/scrape_opta.py
+++ b/scripts/opta/scrape_opta.py
@@ -1103,6 +1103,10 @@ def main():
     parser.add_argument("--heal-dry-run", action="store_true",
                        help="List what the self-heal pass would re-fetch (per comp) "
                             "without making API calls.")
+    parser.add_argument("--dry-run", action="store_true",
+                       help="Build the scrape plan, load + reconcile the manifest "
+                            "(read-only), print what WOULD be scraped, then exit "
+                            "before any API calls or writes (pannadata#36).")
     args = parser.parse_args()
 
     # Determine what to scrape
@@ -1118,21 +1122,38 @@ def main():
         league_seasons = seasons_config[league]
 
         if args.seasons:
-            # Filter to specified seasons
+            # Filter to specified seasons. Explicit --seasons is honoured as-is
+            # (operators may pre-pull a not-yet-started future calendar on demand);
+            # the post-loop future-season guard below trims those if appropriate.
             seasons = [(s, sid) for s, sid in league_seasons.items() if s in args.seasons]
         elif args.recent > 0:
-            # Get N most recent seasons
-            sorted_seasons = sorted(league_seasons.items(), reverse=True)
+            # Get N most recent ACTIVE seasons. Filter out future (not-yet-started)
+            # seasons BEFORE slicing — otherwise --recent 1 can land on a future
+            # label (e.g. "2026-2027") that the later guard strips, leaving the
+            # league with ZERO seasons and freezing the still-active season's
+            # fixtures at status=Fixture (pannadata#60).
+            sorted_seasons = sorted(
+                ((s, sid) for s, sid in league_seasons.items() if not is_future_season(s)),
+                reverse=True,
+            )
             seasons = sorted_seasons[:args.recent]
         else:
-            # Default: current season only
-            sorted_seasons = sorted(league_seasons.items(), reverse=True)
+            # Default: current (most-recent active) season only — same future-
+            # season filtering as the --recent path so we never default onto a
+            # not-yet-started label.
+            sorted_seasons = sorted(
+                ((s, sid) for s, sid in league_seasons.items() if not is_future_season(s)),
+                reverse=True,
+            )
             seasons = sorted_seasons[:1]
 
         for season_name, season_id in seasons:
             scrape_plan.append((league, season_name, season_id))
 
-    # Filter out future seasons (e.g., Club_World_Cup 2029, UEFA_Euros 2028)
+    # Future-season guard for the explicit --seasons path. The --recent/default
+    # paths already filtered future seasons before slicing (above); this remains
+    # as a guard so an operator-specified future label is dropped unless that's
+    # the intent. (e.g., Club_World_Cup 2029, UEFA_Euros 2028)
     original_count = len(scrape_plan)
     scrape_plan = [(l, s, sid) for l, s, sid in scrape_plan if not is_future_season(s)]
     if len(scrape_plan) < original_count:
@@ -1211,6 +1232,25 @@ def main():
         print(f"Manifest: {len(complete_matches):,} complete, "
               f"{len(unavailable_matches):,} unavailable, "
               f"{n_invalidated} reconciled this run")
+
+    # Dry-run short-circuit (pannadata#36). Runs AFTER reconcile (which is
+    # read-only) so the reconcile preview is shown, but BEFORE any API calls
+    # or writes. Reports, per (league, season), how many matches are already
+    # complete in the manifest; the run would scrape NEW played matches in the
+    # window on top of that.
+    if args.dry_run:
+        print("=" * 60)
+        print("DRY RUN — exiting before API calls / writes")
+        print("=" * 60)
+        for league, season_name, _ in scrape_plan:
+            n_complete = sum(
+                1 for (_mid, comp, seas) in complete_matches
+                if comp == league and seas == season_name
+            )
+            print(f"  - {league} {season_name}: {n_complete} already complete in manifest; "
+                  f"would scrape NEW played matches in the window")
+        print(f"Reconcile would invalidate (re-scrape): {n_invalidated} matches")
+        return
 
     # Execute scraping with incremental manifest saves
     results = []

--- a/scripts/opta/test_reconcile.py
+++ b/scripts/opta/test_reconcile.py
@@ -1,0 +1,151 @@
+"""Tests for reconcile_events_with_manifest() in scrape_opta.py.
+
+This is the panna#59 regression guard: it invalidates manifest entries that
+claim has_match_events=True but whose match_id is absent from the consolidated
+opta_events.parquet (a "scrape gap"), so the match gets re-scraped instead of
+silently losing its goals downstream.
+
+Imported by bare name (`from scrape_opta import ...`) — pytest must run with
+scripts/opta as rootdir (see pytest.ini).
+"""
+import pandas as pd
+import pyarrow
+import pytest
+
+from scrape_opta import reconcile_events_with_manifest
+
+
+def test_regression_pin_invalidates_missing_keeps_present(opta_dir, write_events):
+    """A manifest entry that events.parquet lacks is invalidated and dropped;
+    a present one is kept. Pin the panna#59 behaviour.
+
+    To stay under the 25% hard-fail threshold, the scoped set has many present
+    matches and a single missing one (1/8 = 12.5% invalidation).
+    """
+    season = "2025-2026"
+    comp = "Championship"
+    present = [(f"m{i}", comp, season) for i in range(7)]
+    missing = ("gap_match", comp, season)
+
+    # events.parquet contains only the present matches (the gap match's events
+    # silently failed to publish).
+    write_events(present)
+
+    complete = set(present) | {missing}
+    scrape_plan = [(comp, season, "sid_123")]
+
+    pruned, n_invalidated = reconcile_events_with_manifest(opta_dir, complete, scrape_plan)
+
+    assert n_invalidated == 1
+    assert missing not in pruned
+    for p in present:
+        assert p in pruned
+    assert len(pruned) == len(present)
+
+
+def test_corrupt_parquet_is_resilient(opta_dir, write_events):
+    """A corrupt/unreadable opta_events.parquet logs an error and returns the
+    complete set unchanged (no crash)."""
+    path = opta_dir / "opta_events.parquet"
+    path.write_bytes(b"this is not a parquet file")
+
+    complete = {("m1", "EPL", "2025-2026"), ("m2", "EPL", "2025-2026")}
+    scrape_plan = [("EPL", "2025-2026", "sid")]
+
+    pruned, n_invalidated = reconcile_events_with_manifest(opta_dir, complete, scrape_plan)
+
+    assert pruned == complete
+    assert n_invalidated == 0
+
+
+def test_out_of_scope_entries_preserved(opta_dir, write_events):
+    """Only matches whose (competition, season) is in scrape_plan are
+    considered. Out-of-scope manifest entries are preserved even if absent
+    from events.parquet."""
+    # events.parquet has nothing for the out-of-scope league.
+    write_events([("e1", "EPL", "2025-2026")])
+
+    in_scope_present = ("e1", "EPL", "2025-2026")
+    out_of_scope_absent = ("g1", "Bundesliga", "2025-2026")
+    complete = {in_scope_present, out_of_scope_absent}
+
+    # Plan only covers EPL — the Bundesliga entry must not be touched.
+    scrape_plan = [("EPL", "2025-2026", "sid")]
+
+    pruned, n_invalidated = reconcile_events_with_manifest(opta_dir, complete, scrape_plan)
+
+    assert n_invalidated == 0
+    assert out_of_scope_absent in pruned
+    assert in_scope_present in pruned
+
+
+def test_empty_complete_matches(opta_dir):
+    """Empty complete_matches short-circuits to (complete_matches, 0) before
+    any file access."""
+    complete = set()
+    pruned, n_invalidated = reconcile_events_with_manifest(opta_dir, complete, [("EPL", "2025-2026", "sid")])
+    assert pruned == complete
+    assert n_invalidated == 0
+
+
+def test_missing_events_file(opta_dir):
+    """No opta_events.parquet (first run, nothing consolidated yet) returns
+    (complete_matches, 0)."""
+    complete = {("m1", "EPL", "2025-2026")}
+    assert not (opta_dir / "opta_events.parquet").exists()
+
+    pruned, n_invalidated = reconcile_events_with_manifest(opta_dir, complete, [("EPL", "2025-2026", "sid")])
+    assert pruned == complete
+    assert n_invalidated == 0
+
+
+def test_all_present_no_invalidation(opta_dir, write_events):
+    """When every scoped complete match is present in events.parquet, nothing
+    is invalidated and the set is returned unchanged."""
+    season = "2025-2026"
+    comp = "La_Liga"
+    matches = [(f"m{i}", comp, season) for i in range(5)]
+    write_events(matches)
+
+    complete = set(matches)
+    scrape_plan = [(comp, season, "sid")]
+
+    pruned, n_invalidated = reconcile_events_with_manifest(opta_dir, complete, scrape_plan)
+
+    assert n_invalidated == 0
+    assert pruned == complete
+
+
+def test_schema_drift_raises_runtimeerror(opta_dir, write_events):
+    """A readable parquet missing a required column (match_id) must raise
+    RuntimeError rather than silently returning an empty (100%-invalidation)
+    frame."""
+    # Valid parquet, but the required `match_id` column has been renamed/dropped.
+    write_events(
+        [("EPL", "2025-2026"), ("EPL", "2025-2026")],
+        columns=("competition", "season"),
+    )
+
+    complete = {("m1", "EPL", "2025-2026")}
+    scrape_plan = [("EPL", "2025-2026", "sid")]
+
+    with pytest.raises(RuntimeError, match="missing required columns"):
+        reconcile_events_with_manifest(opta_dir, complete, scrape_plan)
+
+
+def test_over_25pct_invalidation_raises(opta_dir, write_events):
+    """When >25% of scoped complete entries would be invalidated, raise
+    RuntimeError (the panna#59 regression guard — wrong path invalidated 100%
+    and burned GHA time)."""
+    season = "2025-2026"
+    comp = "EPL"
+    present = [("p1", comp, season)]            # 1 present
+    absent = [(f"a{i}", comp, season) for i in range(3)]  # 3 absent -> 75% invalidation
+
+    write_events(present)
+
+    complete = set(present) | set(absent)
+    scrape_plan = [(comp, season, "sid")]
+
+    with pytest.raises(RuntimeError, match="refusing to"):
+        reconcile_events_with_manifest(opta_dir, complete, scrape_plan)


### PR DESCRIPTION
This session's pannadata work (plus 5 pre-existing dev commits: shot_events heal, last_rated_league, xgot fail-loud).

## This session
- fix(xg) #91 — penalty shots -> PENALTY_XG (0.76) in shot enrichment.
- fix(scrape) #60/#36/#37 — keep active season at boundary + --dry-run + job-summary stats.
- feat(blog-data) #62 — fail build when expected artifacts missing.
- fix(chains) #76 — don't split possession on keeper save/parry/block.
- test(opta) #34 — pytest infra + reconcile tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)