### PR TITLE
rebuild-events accumulate fix (Option A) + tournament event-timing dataset

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -101,6 +101,16 @@ jobs:
             echo "::notice::shootout_wpa.parquet not available — shootout WPA absent (no shootouts yet, or step 10d not run)"
           fi
 
+          # Tournament event-timing (slim per-event timing for the cross-tournament
+          # cooling/hydration-break analysis — match_id, minute, second, period_id,
+          # type_id + home/away across WC/Euro/AFCON/Copa/Asian Cup/Gold Cup, all
+          # seasons). Pass straight through to R2 as football/tournament-events-timing.parquet.
+          if gh release download blog-latest -p "tournament-events-timing.parquet" -D blog/; then
+            echo "Downloaded tournament-events-timing.parquet"
+          else
+            echo "::notice::tournament-events-timing.parquet not available — cross-tournament breaks panel will be empty"
+          fi
+
           # Action equity (per-action EPV credit — optional, used by chain builder)
           if gh release download blog-latest -p "action_equity.parquet" -D source/; then
             echo "Downloaded action_equity.parquet"

--- a/.github/workflows/rebuild-events.yml
+++ b/.github/workflows/rebuild-events.yml
@@ -104,6 +104,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd data
+          # Pull the EXISTING consolidated events for this comp BEFORE we rebuild,
+          # so we can MERGE (accumulate) rather than replace. rebuild_events.py
+          # fetched only one season, so consolidate writes a single-season file;
+          # without this merge the upload would clobber every other season already
+          # on opta-latest (the 2026-06 Championship/UCL single-season regression).
+          mkdir -p /tmp/prior
+          gh release download opta-latest --pattern "events_${{ inputs.competition }}.parquet" \
+            --dir /tmp/prior 2>/dev/null || true
           # Force coverage check to pick up the new per-league rows
           OPTA_CONSOLIDATE_FORCE=1 python ../scripts/opta/consolidate_opta.py
           # Upload the affected per-league + consolidated files
@@ -112,8 +120,14 @@ jobs:
             # consolidate_events_by_league() to opta/events_consolidated/
             UP_FILE="opta/events_consolidated/events_${{ inputs.competition }}.parquet"
             if [ -f "$UP_FILE" ]; then
+              # Accumulate: union the prior consolidated seasons with this run's
+              # season (new data wins on overlap) so seasons add up across runs.
+              PRIOR="/tmp/prior/events_${{ inputs.competition }}.parquet"
+              if [ -f "$PRIOR" ]; then
+                python ../scripts/opta/merge_events_accumulate.py "$PRIOR" "$UP_FILE" "$UP_FILE"
+              fi
               gh release upload opta-latest "$UP_FILE" --repo peteowen1/pannadata --clobber
-              echo "Uploaded $UP_FILE"
+              echo "Uploaded $UP_FILE (accumulated)"
             fi
           fi
           # Upload the event-less registry if rebuild recorded any (matches Opta

--- a/scripts/opta/build_tournament_events_timing.R
+++ b/scripts/opta/build_tournament_events_timing.R
@@ -1,0 +1,66 @@
+# Build a slim per-tournament event-TIMING dataset for the inthegame-blog
+# hydration-break / cooling-break cross-tournament analysis.
+#
+# Output: tournament_events_timing.parquet — ONE row per in-play event, columns:
+#   tournament, season, match_id, home_team, away_team, minute, second,
+#   period_id, type_id
+# No coords / qualifiers / player / EPV — just enough for the gap-based break
+# detector + shot-rate flow analysis. The blog runs the (calibrated) detector;
+# we ship raw timing only.
+#
+# Covers every season in each consolidated file → the 6 hot-climate targets AND
+# the older/cool CONTROLS in one shot. WC 2022/2026 are NOT in the consolidated
+# WC file (2002-2018); flagged for a separate fetch.
+
+suppressMessages({library(arrow); library(data.table)})
+
+comps <- c("World_Cup", "UEFA_Euros", "AFCON", "Copa_America",
+           "AFC_Asian_Cup", "CONCACAF_Gold_Cup", "Club_World_Cup")
+ev_dir  <- "data/opta/events_consolidated"
+fx_path <- "data/opta/opta_fixtures.parquet"
+
+fixtures <- if (file.exists(fx_path)) {
+  fx <- as.data.table(read_parquet(fx_path))
+  unique(fx[, .(match_id, home_team, away_team)])
+} else NULL
+
+keep <- c("match_id", "minute", "second", "period_id", "type_id",
+          "competition", "season")
+
+out <- list()
+for (cp in comps) {
+  f <- file.path(ev_dir, sprintf("events_%s.parquet", cp))
+  if (!file.exists(f)) { message(sprintf("  skip %s (no file)", cp)); next }
+  dt <- as.data.table(read_parquet(f))
+  miss <- setdiff(c("match_id","minute","second","period_id","type_id"), names(dt))
+  if (length(miss)) { message(sprintf("  skip %s (missing %s)", cp, paste(miss, collapse=","))); next }
+  # In-play periods only (1=1H,2=2H,3/4=ET) — drops pre-match/warmup markers,
+  # keeps everything the break + shot-rate analysis needs.
+  dt <- dt[period_id %in% 1:4]
+  dt[, tournament := if ("competition" %in% names(dt)) competition else cp]
+  if (!"season" %in% names(dt)) dt[, season := NA_character_]
+  slim <- dt[, .(tournament, season = as.character(season), match_id,
+                 minute = as.integer(minute), second = as.integer(second),
+                 period_id = as.integer(period_id), type_id = as.integer(type_id))]
+  if (!is.null(fixtures)) {
+    slim <- merge(slim, fixtures, by = "match_id", all.x = TRUE, sort = FALSE)
+  } else { slim[, home_team := NA_character_]; slim[, away_team := NA_character_] }
+  setcolorder(slim, c("tournament","season","match_id","home_team","away_team",
+                      "minute","second","period_id","type_id"))
+  out[[cp]] <- slim
+  message(sprintf("  %-20s %7d events | %4d matches | %2d seasons | home/away %.0f%%",
+                  cp, nrow(slim), uniqueN(slim$match_id), uniqueN(slim$season),
+                  100 * mean(!is.na(slim$home_team))))
+}
+
+combined <- rbindlist(out, use.names = TRUE, fill = TRUE)
+setorder(combined, tournament, season, match_id, period_id, minute, second)
+
+out_path <- "data/opta/tournament_events_timing.parquet"
+write_parquet(combined, out_path)
+message(sprintf("\nWritten %s: %d rows, %d matches, %.1f MB",
+                out_path, nrow(combined), uniqueN(combined$match_id),
+                file.size(out_path) / 1048576))
+message("Tournaments x seasons:")
+print(combined[, .(matches = uniqueN(match_id), events = .N),
+               by = .(tournament, season)][order(tournament, season)])

--- a/scripts/opta/merge_events_accumulate.py
+++ b/scripts/opta/merge_events_accumulate.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Accumulate a freshly-built single-season events_<comp>.parquet onto the prior
+consolidated file, so rebuild-events ADDS a season instead of replacing the file.
+
+rebuild_events.py fetches one season into the runner; consolidate_opta.py then
+rebuilds events_<comp>.parquet from only that season. Without this merge, the
+upload clobbers every other season already on opta-latest. Here we union the
+prior consolidated (downloaded from opta-latest) with the new season, letting the
+freshly-scraped data win for any overlapping match_ids (a genuine re-scrape).
+
+Usage: merge_events_accumulate.py <prior.parquet> <new.parquet> <out.parquet>
+A missing/empty prior is fine (first season for the comp).
+"""
+import sys
+import pandas as pd
+
+prior_path, new_path, out_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+new = pd.read_parquet(new_path)
+try:
+    prior = pd.read_parquet(prior_path)
+    if prior.empty:
+        raise ValueError("empty prior")
+except Exception as e:  # missing file, unreadable, or empty
+    print(f"merge_events_accumulate: no usable prior ({e}); shipping new only")
+    prior = new.iloc[0:0]
+
+# Drop prior rows whose match_id is in the new (refreshed) data, then concat —
+# this keeps all events for non-overlapping matches and replaces re-scraped ones.
+new_ids = set(new["match_id"].unique())
+keep = prior[~prior["match_id"].isin(new_ids)]
+out = pd.concat([keep, new], ignore_index=True)
+out.to_parquet(out_path, index=False)
+
+print(
+    f"accumulate: prior={prior['match_id'].nunique()} matches, "
+    f"new={new['match_id'].nunique()}, union={out['match_id'].nunique()} matches"
+)


### PR DESCRIPTION
Ships this session's data-pipeline fixes to main so future automated runs use them.

- **rebuild-events accumulate fix (Option A)**: the consolidate step now downloads the prior events_<comp>.parquet and unions the new season in (via merge_events_accumulate.py) instead of clobbering — so multi-season re-scrapes work. Without this, each rebuild-events run replaced the whole consolidated file with just its one season (the Championship/UCL single-season regression).
- **Tournament event-timing dataset**: build_tournament_events_timing.R + build-blog-data passes football/tournament-events-timing.parquet through to R2 (powers the inthegame-blog cross-tournament hydration-break analysis).

Both verified live this session (ENG2/UCL re-scraped to 11 seasons each via the accumulate fix; timing dataset live on R2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)