### PR TITLE
build-blog-data: enrich shots with xGOT before shot build (fixes #88)

### DIFF
--- a/.github/workflows/build-blog-data.yml
+++ b/.github/workflows/build-blog-data.yml
@@ -283,6 +283,22 @@ jobs:
             echo "::warning::Skipping player details — lineups file not available"
           fi
 
+      # Post-shot xG (xGOT) for the blog Shooting tab. build_shot_data.R passes
+      # `xgot` straight through IF the source carries it, but opta-latest's shot
+      # events don't always have it (the daily scrape's xGOT step skips when
+      # goalmouth coords aren't present at scrape time). So re-enrich here too —
+      # belt-and-suspenders, exactly like enrich_shots_xg.R above. enrich_shots_xgot.R
+      # self-skips (exit 0) if xgot_model.rds or goalmouth_y/z are absent, so this
+      # never blocks the build. Fixes pannadata#88.
+      - name: Enrich shots with xGOT
+        continue-on-error: true
+        run: |
+          if [ -f source/opta_shot_events.parquet ] && gh release download models -p "xgot_model.rds" -D source/ 2>/dev/null; then
+            Rscript scripts/enrich_shots_xgot.R source/opta_shot_events.parquet source/xgot_model.rds
+          else
+            echo "::notice::Skipping xGOT enrich — shot file or xgot_model.rds unavailable (build_shot_data passes through any existing xgot)"
+          fi
+
       - name: Build shot parquet
         run: |
           if [ -f source/opta_shot_events.parquet ]; then


### PR DESCRIPTION
Adds an xGOT enrichment step to build-blog-data (mirrors the existing xg re-enrichment): downloads `xgot_model.rds` and runs `enrich_shots_xgot.R` before `build_shot_data.R`, so the blog shots parquet ships per-shot `xgot` even when opta-latest's source lacks it. Self-skips if the model/goalmouth coords are absent (never blocks). Verified end-to-end locally (~1.58M on-target shots enriched; xgot on 270k blog shots).

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)